### PR TITLE
Fixing issues uncovered during Sample cleanup

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Egress/AtemporalArray/AtemporalArrayEgressPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/AtemporalArray/AtemporalArrayEgressPipe.cs
@@ -114,7 +114,7 @@ namespace Microsoft.StreamProcessing
         public override void OnCompleted()
         {
             OnFlush();
-            this.observer.OnCompleted();
+            base.OnCompleted();
         }
 
         public override void OnFlush()

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/AtemporalArray/AtemporalArrayEgressPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/AtemporalArray/AtemporalArrayEgressPipe.cs
@@ -111,6 +111,23 @@ namespace Microsoft.StreamProcessing
             queue.Add(payload);
         }
 
+        public override void OnCompleted()
+        {
+            OnFlush();
+            this.observer.OnCompleted();
+        }
+
+        public override void OnFlush()
+        {
+            if (this.populationCount > 0)
+            {
+                this.observer.OnNext(new ArraySegment<TPayload>(this.array, 0, this.arrayLength));
+                this.populationCount = 0;
+                this.array = this.generator();
+                this.arrayLength = this.array.Length;
+            }
+        }
+
         public override int CurrentlyBufferedOutputCount => this.populationCount;
 
         public override int CurrentlyBufferedInputCount => this.toDelete.Values.Select(o => o.Count).Sum();

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/EgressBoundary.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/EgressBoundary.cs
@@ -76,24 +76,24 @@ namespace Microsoft.StreamProcessing.Internal
         public void OnError(Exception error)
         {
             if (this is IDisposable disposable) disposable.Dispose();
-            observer.OnError(error);
+            this.observer.OnError(error);
         }
 
         /// <summary>
         /// Currently for internal use only - do not use directly.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void OnCompleted()
+        public virtual void OnCompleted()
         {
             if (this is IDisposable disposable) disposable.Dispose();
-            observer.OnCompleted();
+            this.observer.OnCompleted();
         }
 
         /// <summary>
         /// Currently for internal use only - do not use directly.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void OnFlush() { }
+        public virtual void OnFlush() { }
 
         /// <summary>
         /// Currently for internal use only - do not use directly.

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressPipe.cs
@@ -60,6 +60,23 @@ namespace Microsoft.StreamProcessing
                 batch.Free();
             }
 
+            public override void OnCompleted()
+            {
+                OnFlush();
+                this.observer.OnCompleted();
+            }
+
+            public override void OnFlush()
+            {
+                if (this.populationCount > 0)
+                {
+                    this.observer.OnNext(new ArraySegment<StreamEvent<TPayload>>(this.array, 0, this.populationCount));
+                    this.populationCount = 0;
+                    this.array = this.generator();
+                    this.arrayLength = this.array.Length;
+                }
+            }
+
             public override int CurrentlyBufferedOutputCount => this.populationCount;
 
             public override int CurrentlyBufferedInputCount => 0;
@@ -118,6 +135,23 @@ namespace Microsoft.StreamProcessing
                 batch.Free();
             }
 
+            public override void OnCompleted()
+            {
+                OnFlush();
+                this.observer.OnCompleted();
+            }
+
+            public override void OnFlush()
+            {
+                if (this.populationCount > 0)
+                {
+                    this.observer.OnNext(new ArraySegment<TResult>(this.array, 0, this.populationCount));
+                    this.populationCount = 0;
+                    this.array = this.generator();
+                    this.arrayLength = this.array.Length;
+                }
+            }
+
             public override int CurrentlyBufferedOutputCount => this.populationCount;
 
             public override int CurrentlyBufferedInputCount => 0;
@@ -172,6 +206,23 @@ namespace Microsoft.StreamProcessing
                     }
                 }
                 batch.Free();
+            }
+
+            public override void OnCompleted()
+            {
+                OnFlush();
+                this.observer.OnCompleted();
+            }
+
+            public override void OnFlush()
+            {
+                if (this.populationCount > 0)
+                {
+                    this.observer.OnNext(new ArraySegment<TResult>(this.array, 0, this.populationCount));
+                    this.populationCount = 0;
+                    this.array = this.generator();
+                    this.arrayLength = this.array.Length;
+                }
             }
 
             public override int CurrentlyBufferedOutputCount => this.populationCount;
@@ -230,6 +281,23 @@ namespace Microsoft.StreamProcessing
                     }
                 }
                 batch.Free();
+            }
+
+            public override void OnCompleted()
+            {
+                OnFlush();
+                this.observer.OnCompleted();
+            }
+
+            public override void OnFlush()
+            {
+                if (this.populationCount > 0)
+                {
+                    this.observer.OnNext(new ArraySegment<PartitionedStreamEvent<TKey, TPayload>>(this.array, 0, this.populationCount));
+                    this.populationCount = 0;
+                    this.array = this.generator();
+                    this.arrayLength = this.array.Length;
+                }
             }
 
             public override int CurrentlyBufferedOutputCount => this.populationCount;
@@ -291,6 +359,23 @@ namespace Microsoft.StreamProcessing
                 batch.Free();
             }
 
+            public override void OnCompleted()
+            {
+                OnFlush();
+                this.observer.OnCompleted();
+            }
+
+            public override void OnFlush()
+            {
+                if (this.populationCount > 0)
+                {
+                    this.observer.OnNext(new ArraySegment<TResult>(this.array, 0, this.populationCount));
+                    this.populationCount = 0;
+                    this.array = this.generator();
+                    this.arrayLength = this.array.Length;
+                }
+            }
+
             public override int CurrentlyBufferedOutputCount => this.populationCount;
 
             public override int CurrentlyBufferedInputCount => 0;
@@ -346,6 +431,23 @@ namespace Microsoft.StreamProcessing
                     }
                 }
                 batch.Free();
+            }
+
+            public override void OnCompleted()
+            {
+                OnFlush();
+                this.observer.OnCompleted();
+            }
+
+            public override void OnFlush()
+            {
+                if (this.populationCount > 0)
+                {
+                    this.observer.OnNext(new ArraySegment<TResult>(this.array, 0, this.populationCount));
+                    this.populationCount = 0;
+                    this.array = this.generator();
+                    this.arrayLength = this.array.Length;
+                }
             }
 
             public override int CurrentlyBufferedOutputCount => this.populationCount;

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressPipe.cs
@@ -63,7 +63,7 @@ namespace Microsoft.StreamProcessing
             public override void OnCompleted()
             {
                 OnFlush();
-                this.observer.OnCompleted();
+                base.OnCompleted();
             }
 
             public override void OnFlush()
@@ -138,7 +138,7 @@ namespace Microsoft.StreamProcessing
             public override void OnCompleted()
             {
                 OnFlush();
-                this.observer.OnCompleted();
+                base.OnCompleted();
             }
 
             public override void OnFlush()
@@ -211,7 +211,7 @@ namespace Microsoft.StreamProcessing
             public override void OnCompleted()
             {
                 OnFlush();
-                this.observer.OnCompleted();
+                base.OnCompleted();
             }
 
             public override void OnFlush()
@@ -286,7 +286,7 @@ namespace Microsoft.StreamProcessing
             public override void OnCompleted()
             {
                 OnFlush();
-                this.observer.OnCompleted();
+                base.OnCompleted();
             }
 
             public override void OnFlush()
@@ -362,7 +362,7 @@ namespace Microsoft.StreamProcessing
             public override void OnCompleted()
             {
                 OnFlush();
-                this.observer.OnCompleted();
+                base.OnCompleted();
             }
 
             public override void OnFlush()
@@ -436,7 +436,7 @@ namespace Microsoft.StreamProcessing
             public override void OnCompleted()
             {
                 OnFlush();
-                this.observer.OnCompleted();
+                base.OnCompleted();
             }
 
             public override void OnFlush()

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressPipe.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressPipe.tt
@@ -134,7 +134,7 @@ namespace Microsoft.StreamProcessing
             public override void OnCompleted()
             {
                 OnFlush();
-                this.observer.OnCompleted();
+                base.OnCompleted();
             }
 
             public override void OnFlush()

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressPipe.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressPipe.tt
@@ -131,6 +131,23 @@ namespace Microsoft.StreamProcessing
                 batch.Free();
             }
 
+            public override void OnCompleted()
+            {
+                OnFlush();
+                this.observer.OnCompleted();
+            }
+
+            public override void OnFlush()
+            {
+                if (this.populationCount > 0)
+                {
+                    this.observer.OnNext(new ArraySegment<<#= egress #>>(this.array, 0, this.populationCount));
+                    this.populationCount = 0;
+                    this.array = this.generator();
+                    this.arrayLength = this.array.Length;
+                }
+            }
+
             public override int CurrentlyBufferedOutputCount => this.populationCount;
 
             public override int CurrentlyBufferedInputCount => 0;

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressTemplate.cs
@@ -141,7 +141,7 @@ internal sealed class ");
     public override void OnCompleted()
     {
         OnFlush();
-        this.observer.OnCompleted();
+        base.OnCompleted();
     }
 
     public override void OnFlush()

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressTemplate.cs
@@ -40,9 +40,9 @@ internal sealed class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputKey));
             this.Write(", ");
             this.Write(this.ToStringHelper.ToStringWithCulture(TPayload));
-            this.Write(">, IDisposable\r\n{\r\n    private readonly IObserver<ArraySegment<");
+            this.Write(", ArraySegment<");
             this.Write(this.ToStringHelper.ToStringWithCulture(egress));
-            this.Write(">> observer;\r\n    private readonly Func<");
+            this.Write(">\r\n{\r\n    private readonly Func<");
             this.Write(this.ToStringHelper.ToStringWithCulture(egress));
             this.Write("[]> generator;\r\n    [DataMember]\r\n    private ");
             this.Write(this.ToStringHelper.ToStringWithCulture(egress));
@@ -59,7 +59,7 @@ internal sealed class ");
             this.Write("[]> generator,\r\n        IObserver<ArraySegment<");
             this.Write(this.ToStringHelper.ToStringWithCulture(egress));
             this.Write(@">> observer)
-        : base()
+        : base(observer, null)
     {
         this.generator = generator;
         this.array = this.generator();
@@ -67,13 +67,7 @@ internal sealed class ");
         this.observer = observer;
     }
 
-    public void Dispose()
-    {
-        if (this.populationCount > 0) this.observer.OnNext(new ArraySegment<");
-            this.Write(this.ToStringHelper.ToStringWithCulture(egress));
-            this.Write(">(this.array, 0, this.populationCount));\r\n        this.populationCount = 0;\r\n    " +
-                    "    this.array = null;\r\n        this.arrayLength = 0;\r\n    }\r\n\r\n    public overr" +
-                    "ide void OnNext(StreamMessage<");
+    public override void OnNext(StreamMessage<");
             this.Write(this.ToStringHelper.ToStringWithCulture(inputKey));
             this.Write(", ");
             this.Write(this.ToStringHelper.ToStringWithCulture(TPayload));
@@ -142,6 +136,25 @@ internal sealed class ");
             }
         }
         batch.Free();
+    }
+
+    public override void OnCompleted()
+    {
+        OnFlush();
+        this.observer.OnCompleted();
+    }
+
+    public override void OnFlush()
+    {
+        if (this.populationCount > 0)
+        {
+            this.observer.OnNext(new ArraySegment<");
+            this.Write(this.ToStringHelper.ToStringWithCulture(egress));
+            this.Write(@">(this.array, 0, this.populationCount));
+            this.populationCount = 0;
+            this.array = this.generator();
+            this.arrayLength = this.array.Length;
+        }
     }
 
     public override int CurrentlyBufferedOutputCount => this.populationCount;

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressTemplate.tt
@@ -90,7 +90,7 @@ internal sealed class <#= partitionString #><#= ingressType #>EgressPipe : Egres
     public override void OnCompleted()
     {
         OnFlush();
-        this.observer.OnCompleted();
+        base.OnCompleted();
     }
 
     public override void OnFlush()

--- a/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/TemporalArray/TemporalArrayEgressTemplate.tt
@@ -11,9 +11,8 @@ using System.Runtime.Serialization;
 using Microsoft.StreamProcessing.Internal;
 
 [DataContract]
-internal sealed class <#= partitionString #><#= ingressType #>EgressPipe : EgressBoundary<<#= inputKey #>, <#= TPayload #>>, IDisposable
+internal sealed class <#= partitionString #><#= ingressType #>EgressPipe : EgressBoundary<<#= inputKey #>, <#= TPayload #>, ArraySegment<<#= egress #>>
 {
-    private readonly IObserver<ArraySegment<<#= egress #>>> observer;
     private readonly Func<<#= egress #>[]> generator;
     [DataMember]
     private <#= egress #>[] array;
@@ -28,20 +27,12 @@ internal sealed class <#= partitionString #><#= ingressType #>EgressPipe : Egres
     public <#= partitionString #><#= ingressType #>EgressPipe(
         Func<<#= egress #>[]> generator,
         IObserver<ArraySegment<<#= egress #>>> observer)
-        : base()
+        : base(observer, null)
     {
         this.generator = generator;
         this.array = this.generator();
         this.arrayLength = this.array.Length;
         this.observer = observer;
-    }
-
-    public void Dispose()
-    {
-        if (this.populationCount > 0) this.observer.OnNext(new ArraySegment<<#= egress #>>(this.array, 0, this.populationCount));
-        this.populationCount = 0;
-        this.array = null;
-        this.arrayLength = 0;
     }
 
     public override void OnNext(StreamMessage<<#= inputKey #>, <#= TPayload #>> batch)
@@ -94,6 +85,23 @@ internal sealed class <#= partitionString #><#= ingressType #>EgressPipe : Egres
             }
         }
         batch.Free();
+    }
+
+    public override void OnCompleted()
+    {
+        OnFlush();
+        this.observer.OnCompleted();
+    }
+
+    public override void OnFlush()
+    {
+        if (this.populationCount > 0)
+        {
+            this.observer.OnNext(new ArraySegment<<#= egress #>>(this.array, 0, this.populationCount));
+            this.populationCount = 0;
+            this.array = this.generator();
+            this.arrayLength = this.array.Length;
+        }
     }
 
     public override int CurrentlyBufferedOutputCount => this.populationCount;

--- a/Sources/Core/Microsoft.StreamProcessing/Events/StreamEvent.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Events/StreamEvent.cs
@@ -144,15 +144,15 @@ namespace Microsoft.StreamProcessing
             switch (this.Kind)
             {
                 case StreamEventKind.Start:
-                    return string.Format(CultureInfo.InvariantCulture, "[Start: {0},{1}]", TimeAsString(this.SyncTime), this.Payload.ToString());
+                    return $"[{this.Kind}: {TimeAsString(this.SyncTime)},{this.Payload}]";
                 case StreamEventKind.End:
-                    return string.Format(CultureInfo.InvariantCulture, "[End: {0},{1},{2}]", TimeAsString(this.SyncTime), TimeAsString(this.OtherTime), this.Payload.ToString());
+                    return $"[{this.Kind}: {TimeAsString(this.SyncTime)},{TimeAsString(this.OtherTime)},{this.Payload}]";
                 case StreamEventKind.Interval:
-                    return string.Format(CultureInfo.InvariantCulture, "[Interval: {0}-{1},{2}]", TimeAsString(this.SyncTime), TimeAsString(this.OtherTime), this.Payload.ToString());
+                    return $"[{this.Kind}: {TimeAsString(this.SyncTime)}-{TimeAsString(this.OtherTime)},{this.Payload}]";
                 case StreamEventKind.Punctuation:
-                    return string.Format(CultureInfo.InvariantCulture, "[Punc: {0}]", TimeAsString(this.SyncTime));
+                    return $"[{this.Kind}: {TimeAsString(this.SyncTime)}]";
                 case StreamEventKind.LowWatermark:
-                    return string.Format(CultureInfo.InvariantCulture, "[Low Watermark: {0}]", TimeAsString(this.SyncTime));
+                    return $"[{this.Kind}: {TimeAsString(this.SyncTime)}]";
             }
             return string.Empty;
         }
@@ -312,19 +312,18 @@ namespace Microsoft.StreamProcessing
         /// <returns>A string representing the event for display</returns>
         public override string ToString()
         {
-            string fragment = "(" + this.PartitionKey.ToString() + ")";
             switch (this.Kind)
             {
                 case StreamEventKind.Start:
-                    return string.Format(CultureInfo.InvariantCulture, fragment + "[Start: {0},{1}]", TimeAsString(this.SyncTime), this.Payload.ToString());
+                    return $"({this.PartitionKey})[{this.Kind}: {TimeAsString(this.SyncTime)},{this.Payload}]";
                 case StreamEventKind.End:
-                    return string.Format(CultureInfo.InvariantCulture, fragment + "[End: {0},{1},{2}]", TimeAsString(this.SyncTime), TimeAsString(this.OtherTime), this.Payload.ToString());
+                    return $"({this.PartitionKey})[{this.Kind}: {TimeAsString(this.SyncTime)},{TimeAsString(this.OtherTime)},{this.Payload}]";
                 case StreamEventKind.Interval:
-                    return string.Format(CultureInfo.InvariantCulture, fragment + "[Interval: {0}-{1},{2}]", TimeAsString(this.SyncTime), TimeAsString(this.OtherTime), this.Payload.ToString());
+                    return $"({this.PartitionKey})[{this.Kind}: {TimeAsString(this.SyncTime)}-{TimeAsString(this.OtherTime)},{this.Payload}]";
                 case StreamEventKind.Punctuation:
-                    return string.Format(CultureInfo.InvariantCulture, fragment + "[Punc: {0}]", TimeAsString(this.SyncTime));
+                    return $"({this.PartitionKey})[{this.Kind}: {TimeAsString(this.SyncTime)}]";
                 case StreamEventKind.LowWatermark:
-                    return string.Format(CultureInfo.InvariantCulture, "[Low Watermark: {0}]", TimeAsString(this.SyncTime));
+                    return $"[{this.Kind}: {TimeAsString(this.SyncTime)}]";
             }
             return string.Empty;
         }

--- a/Sources/Core/Microsoft.StreamProcessing/Events/StreamEvent.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Events/StreamEvent.tt
@@ -21,7 +21,9 @@ namespace Microsoft.StreamProcessing
     string[] keyParameter = new string[] { string.Empty, "TKey key, " };
     string[] keyArgument = new string[] { string.Empty, "key, " };
     string[] toStringFragment = new string[] { string.Empty, "fragment + " };
-    for (int i = 0; i < classNames.Length; i++) {
+    for (int i = 0; i < classNames.Length; i++)
+    {
+        bool partitioned = (i == 1);
 #>
 
     internal class <#= classNames[i] #>SyncTimeComparer<<#= genericParameters[i] #>> : IComparer<<#= classNames[i] #><<#= genericParameters[i] #>>>
@@ -33,20 +35,24 @@ namespace Microsoft.StreamProcessing
     }
 
     /// <summary>
-    /// Represents <#= (i == 1) ? "a partitioned" : "an unpartitioned" #> Stream event
+    /// Represents <#= partitioned ? "a partitioned" : "an unpartitioned" #> Stream event
     /// </summary>
-<# if (i == 1) { #>    /// <typeparam name="TKey">Type of payload for the event</typeparam>
-<# } #>    /// <typeparam name="TPayload">Type of payload for the event</typeparam>
+<#  if (partitioned)
+    { #>
+    /// <typeparam name="TKey">Type of payload for the event</typeparam>
+<#  } #>
+    /// <typeparam name="TPayload">Type of payload for the event</typeparam>
     [DataContract]
     public struct <#= classNames[i] #><<#= genericParameters[i] #>>
     {
-<# if (i == 1) { #>
+<#  if (partitioned)
+    { #>
         /// <summary>
         /// Partition key for the event
         /// </summary>
         [DataMember]
         public TKey PartitionKey;
-<# } #>
+<#  } #>
 
         /// <summary>
         /// Start-time for the event
@@ -109,7 +115,7 @@ namespace Microsoft.StreamProcessing
         /// </summary>
         public bool IsPunctuation => this.OtherTime == StreamEvent.PunctuationOtherTime;
 
-<#  if (i == 1)
+<#  if (partitioned)
     { #>
         /// <summary>
         /// Check if the event is a punctuation
@@ -155,17 +161,19 @@ namespace Microsoft.StreamProcessing
         /// <summary>
         /// Creates a new stream event with the given temporal parameters.
         /// </summary>
-<# if (i == 1) { #>
+<#  if (partitioned)
+    { #>
         /// <param name="key">The partition key value to which this event belongs.</param>
-<# } #>
+<#  } #>
         /// <param name="syncTime">The sync time for this event. This value corresponds to the start time for a start edge or interval and the end time for an end edge.</param>
         /// <param name="otherTime">The other associated time for this events. For intervals, this value is the end time. For an end edge, this value identifies when the value started.</param>
         /// <param name="payload">The actual event associated with these temporal parameters.</param>
         public <#= classNames[i] #>(<#= keyParameter[i] #>long syncTime, long otherTime, TPayload payload)
         {
-<# if (i == 1) { #>
+<#  if (partitioned)
+    { #>
             this.PartitionKey = key;
-<# } #>
+<#  } #>
             this.SyncTime = syncTime;
             this.OtherTime = otherTime;
             this.Payload = payload;
@@ -177,21 +185,18 @@ namespace Microsoft.StreamProcessing
         /// <returns>A string representing the event for display</returns>
         public override string ToString()
         {
-<# if (i == 1) { #>
-            string fragment = "(" + this.PartitionKey.ToString() + ")";
-<# } #>
             switch (this.Kind)
             {
                 case StreamEventKind.Start:
-                    return string.Format(CultureInfo.InvariantCulture, <#= toStringFragment[i] #>"[Start: {0},{1}]", TimeAsString(this.SyncTime), this.Payload.ToString());
+                    return $"<#= partitioned ? "({this.PartitionKey})" : "" #>[{this.Kind}: {TimeAsString(this.SyncTime)},{this.Payload}]";
                 case StreamEventKind.End:
-                    return string.Format(CultureInfo.InvariantCulture, <#= toStringFragment[i] #>"[End: {0},{1},{2}]", TimeAsString(this.SyncTime), TimeAsString(this.OtherTime), this.Payload.ToString());
+                    return $"<#= partitioned ? "({this.PartitionKey})" : "" #>[{this.Kind}: {TimeAsString(this.SyncTime)},{TimeAsString(this.OtherTime)},{this.Payload}]";
                 case StreamEventKind.Interval:
-                    return string.Format(CultureInfo.InvariantCulture, <#= toStringFragment[i] #>"[Interval: {0}-{1},{2}]", TimeAsString(this.SyncTime), TimeAsString(this.OtherTime), this.Payload.ToString());
+                    return $"<#= partitioned ? "({this.PartitionKey})" : "" #>[{this.Kind}: {TimeAsString(this.SyncTime)}-{TimeAsString(this.OtherTime)},{this.Payload}]";
                 case StreamEventKind.Punctuation:
-                    return string.Format(CultureInfo.InvariantCulture, <#= toStringFragment[i] #>"[Punc: {0}]", TimeAsString(this.SyncTime));
+                    return $"<#= partitioned ? "({this.PartitionKey})" : "" #>[{this.Kind}: {TimeAsString(this.SyncTime)}]";
                 case StreamEventKind.LowWatermark:
-                    return string.Format(CultureInfo.InvariantCulture, "[Low Watermark: {0}]", TimeAsString(this.SyncTime));
+                    return $"[{this.Kind}: {TimeAsString(this.SyncTime)}]";
             }
             return string.Empty;
         }

--- a/Sources/Core/Microsoft.StreamProcessing/StreamableAPI/SelectExtensions.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/StreamableAPI/SelectExtensions.cs
@@ -219,7 +219,7 @@ namespace Microsoft.StreamProcessing
                 o => Expression.Bind(newType.GetTypeInfo().GetMember(o).Single(), Expression.PropertyOrField(inputParameter, o)));
 
             var newFieldAssignments = newColumnFormulas.Select(
-                o => Expression.Bind(newType.GetTypeInfo().GetMember(o.Key).Single(), o.Value.ReplaceParametersInBody(inputParameter)));
+                o => Expression.Bind(newType.GetTypeInfo().GetMember(o.Key).Single(), o.Value.RemoveCastToObject().ReplaceParametersInBody(inputParameter)));
 
             var member = Expression.MemberInit(newExpression, commonFieldAssignments.Concat(newFieldAssignments).ToArray());
             var lambda = Expression.Lambda<Func<TOld, TNew>>(member, new ParameterExpression[] { inputParameter });

--- a/Sources/Core/Microsoft.StreamProcessing/Utilities/ExpressionExtensions.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Utilities/ExpressionExtensions.cs
@@ -115,6 +115,17 @@ namespace Microsoft.StreamProcessing
             return s;
         }
 
+        public static LambdaExpression RemoveCastToObject(this LambdaExpression lambda)
+        {
+            if (lambda.Body is UnaryExpression body &&
+                (body.NodeType == ExpressionType.Convert || body.NodeType == ExpressionType.TypeAs) &&
+                (body.Type == typeof(object)))
+            {
+                return Expression.Lambda(body.Operand, lambda.Parameters);
+            }
+            return lambda;
+        }
+
         public static Expression ReplaceParametersInBody(this LambdaExpression lambda, Expression exp0)
             => ParameterSubstituter.Replace(lambda.Parameters[0], exp0, lambda.Body);
 
@@ -222,10 +233,7 @@ namespace Microsoft.StreamProcessing
         private readonly Dictionary<ParameterExpression, int> parameterMap = new Dictionary<ParameterExpression, int>();
         private int uniqueParameterNumber;
 
-        private EqualityComparer(Expression e1, Expression e2)
-        {
-            this.uniqueParameterNumber = 0;
-        }
+        private EqualityComparer(Expression e1, Expression e2) => this.uniqueParameterNumber = 0;
 
         public static bool IsEqual(Expression e1, Expression e2)
         {
@@ -488,10 +496,7 @@ namespace Microsoft.StreamProcessing
             ExpressionType.Block
         };
 
-        public ConvertToCSharp(TextWriter writer)
-        {
-            this.writer = writer ?? throw new ArgumentNullException(nameof(writer));
-        }
+        public ConvertToCSharp(TextWriter writer) => this.writer = writer ?? throw new ArgumentNullException(nameof(writer));
 
         private new void Visit(ReadOnlyCollection<Expression> es)
         {
@@ -770,7 +775,7 @@ namespace Microsoft.StreamProcessing
         //     returns the original expression.
         protected override Expression VisitDynamic(DynamicExpression node)
         {
-            writer.Write(node.ToString());
+            this.writer.Write(node.ToString());
             return base.VisitDynamic(node);
         }
 #endif


### PR DESCRIPTION
Fixing a few issues discovered while cleaning up the samples at TrillSamples:

- Array Egress pipes had a bug where they would only egress on batch boundaries, not on OnCompleted or OnFlush. Fix is to override OnCompleted and OnFlush to actually flush the pipe's contents.
- PartitionedStreamEvent.ToString() had a null dereference on LowWatermark events, since they do not have a PartitionKey.
- PartitionPipe failed to handle the conversion of a non-partitioned stream punctuation event to a partitioned stream low watermark event. Adding that conversion.
- The Select variants that allowed column expression adjustments did not work with value types because the expression explicitly included a cast to object. Removing this cast when fixes the issue.
- Other minor code cleanup