### PR TITLE
Fix Fx4.6 nuspec dependency list to most recent

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/StreamProcessing.nuspec
+++ b/Sources/Core/Microsoft.StreamProcessing/StreamProcessing.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.CodeAnalysis.Scripting" version="2.9.0" />
-        <dependency id="Microsoft.CSharp" version="4.3.0" />
+        <dependency id="Microsoft.CSharp" version="4.5.0" />
         <dependency id="NETStandard.Library" version="2.0.0" />
         <dependency id="System.Diagnostics.Contracts" version="4.3.0" />
         <dependency id="System.Diagnostics.Process" version="4.3.0" />
@@ -24,24 +24,12 @@
         <dependency id="System.Threading.Thread" version="4.3.0" />
       </group>
       <group targetFramework="net46">
-        <dependency id="Microsoft.CodeAnalysis.CSharp.Scripting" version="1.3.2" />
-        <dependency id="System.Collections.Concurrent" version="4.0.12" />
-        <dependency id="System.Console" version="4.0.0" />
-        <dependency id="System.Diagnostics.FileVersionInfo" version="4.0.0" />
-        <dependency id="System.Dynamic.Runtime" version="4.0.11" />
-        <dependency id="System.Reflection.Primitives" version="4.0.1" />
-        <dependency id="System.Runtime.Handles" version="4.0.1" />
-        <dependency id="System.Runtime.Numerics" version="4.0.1" />
-        <dependency id="System.Security.Cryptography.X509Certificates" version="4.1.0" />
-        <dependency id="System.Text.Encoding" version="4.0.11" />
-        <dependency id="System.Text.Encoding.CodePages" version="4.0.1" />
-        <dependency id="System.Text.Encoding.Extensions" version="4.0.11" />
-        <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
-        <dependency id="System.Threading.Thread" version="4.0.0" />
-        <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
-        <dependency id="System.Xml.XDocument" version="4.0.11" />
-        <dependency id="System.Xml.XmlDocument" version="4.0.1" />
-        <dependency id="System.Xml.XPath.XDocument" version="4.0.1" />
+        <dependency id="Microsoft.CodeAnalysis.Scripting" version="2.9.0" />
+        <dependency id="Microsoft.CSharp" version="4.5.0" />
+        <dependency id="System.Diagnostics.Contracts" version="4.3.0" />
+        <dependency id="System.Diagnostics.Process" version="4.3.0" />
+        <dependency id="System.Runtime.Serialization.Primitives" version="4.3.0" />
+        <dependency id="System.Threading.Thread" version="4.3.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
A user pointed out that our nuspec for Fx46 is way out of date. This PR fixes that issue and brings it into line with netstandard20.