### PR TITLE
Implement ProgressiveQuantize functionality

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/PartitionedQuantizeLifetimePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/PartitionedQuantizeLifetimePipe.cs
@@ -109,7 +109,7 @@ namespace Microsoft.StreamProcessing
                         if (batch.vother.col[i] == StreamEvent.InfinitySyncTime) // Start edge
                         {
                             int ind = this.output.Count++;
-                            this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                            this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                             this.output.vother.col[ind] = StreamEvent.InfinitySyncTime;
                             this.output.key.col[ind] = batch.key.col[i];
                             this.output[ind] = batch[i];
@@ -120,9 +120,9 @@ namespace Microsoft.StreamProcessing
                         else if (batch.vother.col[i] > batch.vsync.col[i]) // Interval
                         {
                             int ind = this.output.Count++;
-                            this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                            this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                             var temp = Math.Max(vother[i] + this.skip - 1, vsync[i] + this.width);
-                            this.output.vother.col[ind] = temp - ((temp - (this.offset + this.width)) % this.skip);
+                            this.output.vother.col[ind] = temp - ((temp - (this.offset + this.width)) % this.skip + this.skip) % this.skip;
                             this.output.key.col[ind] = batch.key.col[i];
                             this.output[ind] = batch[i];
                             this.output.hash.col[ind] = batch.hash.col[i];
@@ -136,8 +136,8 @@ namespace Microsoft.StreamProcessing
 
                             var temp = Math.Max(vsync[i] + this.skip - 1, vother[i] + this.width);
                             int index = intervalMap.Insert(batch.hash.col[i]);
-                            intervalMap.Values[index].Populate(batch.key.col[i], batch[i], batch.hash.col[i], vother[i] - ((vother[i] - this.offset) % this.progress));
-                            endPointHeap.Insert(temp - ((temp - (this.offset + this.width)) % this.skip), index);
+                            intervalMap.Values[index].Populate(batch.key.col[i], batch[i], batch.hash.col[i], vother[i] - ((vother[i] - this.offset) % this.progress + this.progress) % this.progress);
+                            endPointHeap.Insert(temp - ((temp - (this.offset + this.width)) % this.skip + this.skip) % this.skip, index);
                         }
                     }
                     else if (batch.vother.col[i] == PartitionedStreamEvent.LowWatermarkOtherTime)
@@ -145,7 +145,7 @@ namespace Microsoft.StreamProcessing
                         ReachTime(batch.vsync.col[i]);
 
                         int ind = this.output.Count++;
-                        this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                        this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                         this.output.vother.col[ind] = PartitionedStreamEvent.LowWatermarkOtherTime;
                         this.output.key.col[ind] = default;
                         this.output[ind] = default;
@@ -161,7 +161,7 @@ namespace Microsoft.StreamProcessing
                         ReachTime(timeIndex, batch.vsync.col[i]);
 
                         int ind = this.output.Count++;
-                        this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                        this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                         this.output.vother.col[ind] = long.MinValue;
                         this.output.key.col[ind] = batch.key.col[i];
                         this.output[ind] = default;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimePipe.cs
@@ -93,7 +93,7 @@ namespace Microsoft.StreamProcessing
                         if (vother[i] == StreamEvent.InfinitySyncTime) // Start edge
                         {
                             int ind = this.output.Count++;
-                            this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                            this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                             this.output.vother.col[ind] = StreamEvent.InfinitySyncTime;
                             this.output.key.col[ind] = batch.key.col[i];
                             this.output.payload.col[ind] = batch.payload.col[i];
@@ -103,9 +103,9 @@ namespace Microsoft.StreamProcessing
                         else if (vother[i] > vsync[i]) // Interval
                         {
                             int ind = this.output.Count++;
-                            this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                            this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                             var temp = Math.Max(vother[i] + this.skip - 1, vsync[i] + this.width);
-                            this.output.vother.col[ind] = temp - ((temp - (this.offset + this.width)) % this.skip);
+                            this.output.vother.col[ind] = temp - ((temp - (this.offset + this.width)) % this.skip + this.skip) % this.skip;
                             this.output.key.col[ind] = batch.key.col[i];
                             this.output[ind] = batch[i];
                             this.output.hash.col[ind] = batch.hash.col[i];
@@ -115,8 +115,8 @@ namespace Microsoft.StreamProcessing
                         {
                             var temp = Math.Max(vsync[i] + this.skip - 1, vother[i] + this.width);
                             int index = this.intervalMap.Insert(batch.hash.col[i]);
-                            this.intervalMap.Values[index].Populate(batch.key.col[i], batch[i], batch.hash.col[i], vother[i] - ((vother[i] - this.offset) % this.progress));
-                            this.endPointHeap.Insert(temp - ((temp - (this.offset + this.width)) % this.skip), index);
+                            this.intervalMap.Values[index].Populate(batch.key.col[i], batch[i], batch.hash.col[i], vother[i] - ((vother[i] - this.offset) % this.progress + this.progress) % this.progress);
+                            this.endPointHeap.Insert(temp - ((temp - (this.offset + this.width)) % this.skip + this.skip) % this.skip, index);
                         }
                     }
                     else if (vother[i] == long.MinValue) // Punctuation
@@ -124,7 +124,7 @@ namespace Microsoft.StreamProcessing
                         if (vsync[i] > this.lastSyncTime) ReachTime(vsync[i]);
 
                         int ind = this.output.Count++;
-                        this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                        this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                         this.output.vother.col[ind] = long.MinValue;
                         this.output.key.col[ind] = batch.key.col[i];
                         this.output.payload.col[ind] = default;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimePlanNode.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimePlanNode.cs
@@ -20,16 +20,24 @@ namespace Microsoft.StreamProcessing
         /// </summary>
         public long Skip { get; }
         /// <summary>
+        /// Represents the length whose multiples define the left (start) edge of each transformed lifetime
+        /// </summary>
+        public long Progress { get; }
+        /// <summary>
         /// Represents the "zero" from which the interval begins skipping
         /// </summary>
         public long Offset { get; }
 
         internal QuantizeLifetimePlanNode(
             PlanNode previous, IQueryObject pipe,
-            Type keyType, Type payloadType, long width, long skip, long offset,
+            Type keyType, Type payloadType, long width, long skip, long progress, long offset,
             bool isGenerated, string errorMessages, bool withStateManager)
             : base(previous, pipe, keyType, payloadType, payloadType, isGenerated, errorMessages)
         {
+            this.Width = width;
+            this.Skip = skip;
+            this.Progress = progress;
+            this.Offset = offset;
         }
 
         /// <summary>

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimeTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimeTemplate.cs
@@ -39,6 +39,7 @@ using Microsoft.StreamProcessing;
 using Microsoft.StreamProcessing.Aggregates;
 using Microsoft.StreamProcessing.Internal;
 using Microsoft.StreamProcessing.Internal.Collections;
+[assembly: IgnoresAccessChecksTo(""Microsoft.StreamProcessing"")]
 
 [DataContract]
 internal sealed class ");
@@ -78,7 +79,7 @@ internal sealed class ");
     [DataMember]
     private long lastSyncTime = long.MinValue;
     [DataMember]
-    private EndPointHeap endPointHeap = new EndPointHeap();
+    private IEndPointOrderer endPointHeap = new EndPointHeap();
     [DataMember]
     private FastMap<ActiveEvent> intervalMap = new FastMap<ActiveEvent>();
 
@@ -182,43 +183,48 @@ internal sealed class ");
                     "          {\r\n                    if (batch.vsync.col[i] > lastSyncTime) ReachTim" +
                     "e(batch.vsync.col[i]);\r\n\r\n                    if (batch.vother.col[i] == StreamE" +
                     "vent.InfinitySyncTime) // Start edge\r\n                    {\r\n                   " +
-                    "     int ind = output.Count++;\r\n                        output.vsync.col[ind] = " +
-                    "vsync[i] - ((vsync[i] - offset) % progress);\r\n                        output.vot" +
-                    "her.col[ind] = StreamEvent.InfinitySyncTime;\r\n                        output.key" +
-                    ".col[ind] = batch.key.col[i];\r\n                        output[ind] = batch[i];\r\n" +
-                    "                        output.hash.col[ind] = batch.hash.col[i];\r\n\r\n           " +
-                    "             if (output.Count == Config.DataBatchSize) FlushContents();\r\n       " +
-                    "             }\r\n                    else if (batch.vother.col[i] > batch.vsync.c" +
-                    "ol[i]) // Interval\r\n                    {\r\n                        int ind = out" +
-                    "put.Count++;\r\n                        output.vsync.col[ind] = vsync[i] - ((vsync" +
-                    "[i] - offset) % progress);\r\n                        var temp = Math.Max(vother[i" +
-                    "] + skip - 1, vsync[i] + width);\r\n                        output.vother.col[ind]" +
-                    " = temp - ((temp - (offset + width)) % skip);\r\n                        output.ke" +
-                    "y.col[ind] = batch.key.col[i];\r\n                        output[ind] = batch[i];\r" +
-                    "\n                        output.hash.col[ind] = batch.hash.col[i];\r\n\r\n          " +
-                    "              if (output.Count == Config.DataBatchSize) FlushContents();\r\n      " +
-                    "              }\r\n                    else\r\n                    {\r\n              " +
-                    "          var temp = Math.Max(vsync[i] + skip - 1, vother[i] + width);\r\n        " +
-                    "                int index = intervalMap.Insert(batch.hash.col[i]);\r\n            " +
-                    "            intervalMap.Values[index].Populate(batch.key.col[i], batch, i, batch" +
-                    ".hash.col[i], vother[i] - ((vother[i] - offset) % progress));\r\n                 " +
-                    "       endPointHeap.Insert(temp - ((temp - (offset + width)) % skip), index);\r\n " +
-                    "                   }\r\n                }\r\n                else if (vother[i] == l" +
-                    "ong.MinValue) // Punctuation\r\n                {\r\n                    if (vsync[i" +
-                    "] > lastSyncTime) ReachTime(vsync[i]);\r\n\r\n                    int ind = output.C" +
-                    "ount++;\r\n                    output.vsync.col[ind] = vsync[i] - ((vsync[i] - off" +
-                    "set) % progress);\r\n                    output.vother.col[ind] = long.MinValue;\r\n" +
-                    "                    output.key.col[ind] = default;\r\n                    output[i" +
-                    "nd] = default;\r\n                    output.hash.col[ind] = batch.hash.col[i];\r\n " +
-                    "                   output.bitvector.col[ind >> 6] |= (1L << (ind & 0x3f));\r\n    " +
-                    "                if (output.Count == Config.DataBatchSize) FlushContents();\r\n    " +
-                    "            }\r\n            }\r\n        }\r\n        batch.Free();\r\n    }\r\n\r\n    pro" +
-                    "tected override void FlushContents()\r\n    {\r\n        if (output.Count == 0) retu" +
-                    "rn;\r\n        output.Seal();\r\n        this.Observer.OnNext(output);\r\n        GetO" +
-                    "utputBatch();\r\n    }\r\n\r\n    protected override void DisposeState() => output.Fre" +
-                    "e();\r\n\r\n    public override int CurrentlyBufferedOutputCount => output.Count;\r\n\r" +
-                    "\n    public override int CurrentlyBufferedInputCount => intervalMap.Count;\r\n\r\n  " +
-                    "  [DataContract]\r\n    private struct ActiveEvent\r\n    {\r\n");
+                    "     int ind = this.output.Count++;\r\n                        this.output.vsync.c" +
+                    "ol[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) " +
+                    "% this.progress;\r\n                        this.output.vother.col[ind] = StreamEv" +
+                    "ent.InfinitySyncTime;\r\n                        this.output.key.col[ind] = batch." +
+                    "key.col[i];\r\n                        this.output[ind] = batch[i];\r\n             " +
+                    "           this.output.hash.col[ind] = batch.hash.col[i];\r\n                     " +
+                    "   if (this.output.Count == Config.DataBatchSize) FlushContents();\r\n            " +
+                    "        }\r\n                    else if (batch.vother.col[i] > batch.vsync.col[i]" +
+                    ") // Interval\r\n                    {\r\n                        int ind = this.out" +
+                    "put.Count++;\r\n                        this.output.vsync.col[ind] = vsync[i] - ((" +
+                    "vsync[i] - this.offset) % this.progress + this.progress) % this.progress;\r\n     " +
+                    "                   var temp = Math.Max(vother[i] + this.skip - 1, vsync[i] + thi" +
+                    "s.width);\r\n                        this.output.vother.col[ind] = temp - ((temp -" +
+                    " (this.offset + this.width)) % this.skip + this.skip) % this.skip;\r\n            " +
+                    "            this.output.key.col[ind] = batch.key.col[i];\r\n                      " +
+                    "  this.output[ind] = batch[i];\r\n                        this.output.hash.col[ind" +
+                    "] = batch.hash.col[i];\r\n                        if (this.output.Count == Config." +
+                    "DataBatchSize) FlushContents();\r\n                    }\r\n                    else" +
+                    "\r\n                    {\r\n                        var temp = Math.Max(vsync[i] + " +
+                    "this.skip - 1, vother[i] + this.width);\r\n                        int index = thi" +
+                    "s.intervalMap.Insert(batch.hash.col[i]);\r\n                        this.intervalM" +
+                    "ap.Values[index].Populate(batch.key.col[i], batch, i, batch.hash.col[i], vother[" +
+                    "i] - ((vother[i] - this.offset) % this.progress + this.progress) % this.progress" +
+                    ");\r\n                        this.endPointHeap.Insert(temp - ((temp - (this.offse" +
+                    "t + this.width)) % this.skip + this.skip) % this.skip, index);\r\n                " +
+                    "    }\r\n                }\r\n                else if (vother[i] == long.MinValue) /" +
+                    "/ Punctuation\r\n                {\r\n                    if (vsync[i] > this.lastSy" +
+                    "ncTime) ReachTime(vsync[i]);\r\n\r\n                    int ind = this.output.Count+" +
+                    "+;\r\n                    this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - thi" +
+                    "s.offset) % this.progress + this.progress) % this.progress;\r\n                   " +
+                    " this.output.vother.col[ind] = long.MinValue;\r\n                    this.output.k" +
+                    "ey.col[ind] = batch.key.col[i];\r\n                    this.output.payload.col[ind" +
+                    "] = default;\r\n                    this.output.hash.col[ind] = batch.hash.col[i];" +
+                    "\r\n                    this.output.bitvector.col[ind >> 6] |= (1L << (ind & 0x3f)" +
+                    ");\r\n                    if (this.output.Count == Config.DataBatchSize) FlushCont" +
+                    "ents();\r\n                }\r\n            }\r\n        }\r\n        batch.Free();\r\n   " +
+                    " }\r\n\r\n    protected override void FlushContents()\r\n    {\r\n        if (output.Cou" +
+                    "nt == 0) return;\r\n        output.Seal();\r\n        this.Observer.OnNext(output);\r" +
+                    "\n        GetOutputBatch();\r\n    }\r\n\r\n    protected override void DisposeState() " +
+                    "=> output.Free();\r\n\r\n    public override int CurrentlyBufferedOutputCount => out" +
+                    "put.Count;\r\n\r\n    public override int CurrentlyBufferedInputCount => intervalMap" +
+                    ".Count;\r\n\r\n    [DataContract]\r\n    private struct ActiveEvent\r\n    {\r\n");
  foreach (var f in this.fields) { 
             this.Write("        [DataMember]\r\n        public ");
             this.Write(this.ToStringHelper.ToStringWithCulture(f.Type.GetCSharpSourceSyntax()));

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimeTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimeTemplate.tt
@@ -29,6 +29,8 @@ internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : Una
     [SchemaSerialization]
     private readonly long skip;
     [SchemaSerialization]
+    private readonly long progress;
+    [SchemaSerialization]
     private readonly long offset;
 
     private StreamMessage<<#= TKey #>, <#= TPayload #>> genericOutputBatch;
@@ -49,7 +51,7 @@ internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : Una
 
     public <#= className #>(
         IStreamable<<#= TKey #>, <#= TPayload #>> stream,
-        IStreamObserver<<#= TKey #>, <#= TPayload #>> observer, long width, long skip, long offset,
+        IStreamObserver<<#= TKey #>, <#= TPayload #>> observer, long width, long skip, long progress, long offset,
         Func<PlanNode, IQueryObject, PlanNode> queryPlanGenerator)
         : base(stream, observer)
     {
@@ -57,6 +59,7 @@ internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : Una
         this.queryPlanGenerator = queryPlanGenerator;
         GetOutputBatch();
         this.width = width;
+        this.progress = progress;
         this.skip = skip;
         this.offset = offset;
     }
@@ -122,7 +125,7 @@ internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : Una
                     if (batch.vother.col[i] == StreamEvent.InfinitySyncTime) // Start edge
                     {
                         int ind = output.Count++;
-                        output.vsync.col[ind] = vsync[i] - ((vsync[i] - offset) % skip);
+                        output.vsync.col[ind] = vsync[i] - ((vsync[i] - offset) % progress);
                         output.vother.col[ind] = StreamEvent.InfinitySyncTime;
                         output.key.col[ind] = batch.key.col[i];
                         output[ind] = batch[i];
@@ -133,7 +136,7 @@ internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : Una
                     else if (batch.vother.col[i] > batch.vsync.col[i]) // Interval
                     {
                         int ind = output.Count++;
-                        output.vsync.col[ind] = vsync[i] - ((vsync[i] - offset) % skip);
+                        output.vsync.col[ind] = vsync[i] - ((vsync[i] - offset) % progress);
                         var temp = Math.Max(vother[i] + skip - 1, vsync[i] + width);
                         output.vother.col[ind] = temp - ((temp - (offset + width)) % skip);
                         output.key.col[ind] = batch.key.col[i];
@@ -146,7 +149,7 @@ internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : Una
                     {
                         var temp = Math.Max(vsync[i] + skip - 1, vother[i] + width);
                         int index = intervalMap.Insert(batch.hash.col[i]);
-                        intervalMap.Values[index].Populate(batch.key.col[i], batch, i, batch.hash.col[i], vother[i] - ((vother[i] - offset) % skip));
+                        intervalMap.Values[index].Populate(batch.key.col[i], batch, i, batch.hash.col[i], vother[i] - ((vother[i] - offset) % progress));
                         endPointHeap.Insert(temp - ((temp - (offset + width)) % skip), index);
                     }
                 }
@@ -155,7 +158,7 @@ internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : Una
                     if (vsync[i] > lastSyncTime) ReachTime(vsync[i]);
 
                     int ind = output.Count++;
-                    output.vsync.col[ind] = vsync[i] - ((vsync[i] - offset) % skip);
+                    output.vsync.col[ind] = vsync[i] - ((vsync[i] - offset) % progress);
                     output.vother.col[ind] = long.MinValue;
                     output.key.col[ind] = default;
                     output[ind] = default;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimeTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/QuantizeLifetimeTemplate.tt
@@ -17,6 +17,7 @@ using Microsoft.StreamProcessing;
 using Microsoft.StreamProcessing.Aggregates;
 using Microsoft.StreamProcessing.Internal;
 using Microsoft.StreamProcessing.Internal.Collections;
+[assembly: IgnoresAccessChecksTo("Microsoft.StreamProcessing")]
 
 [DataContract]
 internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : UnaryPipe<<#= TKey #>, <#= TPayload #>, <#= TPayload #>>
@@ -40,7 +41,7 @@ internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : Una
     [DataMember]
     private long lastSyncTime = long.MinValue;
     [DataMember]
-    private EndPointHeap endPointHeap = new EndPointHeap();
+    private IEndPointOrderer endPointHeap = new EndPointHeap();
     [DataMember]
     private FastMap<ActiveEvent> intervalMap = new FastMap<ActiveEvent>();
 
@@ -124,47 +125,45 @@ internal sealed class <#= className #><#= TKeyTPayloadGenericParameters #> : Una
 
                     if (batch.vother.col[i] == StreamEvent.InfinitySyncTime) // Start edge
                     {
-                        int ind = output.Count++;
-                        output.vsync.col[ind] = vsync[i] - ((vsync[i] - offset) % progress);
-                        output.vother.col[ind] = StreamEvent.InfinitySyncTime;
-                        output.key.col[ind] = batch.key.col[i];
-                        output[ind] = batch[i];
-                        output.hash.col[ind] = batch.hash.col[i];
-
-                        if (output.Count == Config.DataBatchSize) FlushContents();
+                        int ind = this.output.Count++;
+                        this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
+                        this.output.vother.col[ind] = StreamEvent.InfinitySyncTime;
+                        this.output.key.col[ind] = batch.key.col[i];
+                        this.output[ind] = batch[i];
+                        this.output.hash.col[ind] = batch.hash.col[i];
+                        if (this.output.Count == Config.DataBatchSize) FlushContents();
                     }
                     else if (batch.vother.col[i] > batch.vsync.col[i]) // Interval
                     {
-                        int ind = output.Count++;
-                        output.vsync.col[ind] = vsync[i] - ((vsync[i] - offset) % progress);
-                        var temp = Math.Max(vother[i] + skip - 1, vsync[i] + width);
-                        output.vother.col[ind] = temp - ((temp - (offset + width)) % skip);
-                        output.key.col[ind] = batch.key.col[i];
-                        output[ind] = batch[i];
-                        output.hash.col[ind] = batch.hash.col[i];
-
-                        if (output.Count == Config.DataBatchSize) FlushContents();
+                        int ind = this.output.Count++;
+                        this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
+                        var temp = Math.Max(vother[i] + this.skip - 1, vsync[i] + this.width);
+                        this.output.vother.col[ind] = temp - ((temp - (this.offset + this.width)) % this.skip + this.skip) % this.skip;
+                        this.output.key.col[ind] = batch.key.col[i];
+                        this.output[ind] = batch[i];
+                        this.output.hash.col[ind] = batch.hash.col[i];
+                        if (this.output.Count == Config.DataBatchSize) FlushContents();
                     }
                     else
                     {
-                        var temp = Math.Max(vsync[i] + skip - 1, vother[i] + width);
-                        int index = intervalMap.Insert(batch.hash.col[i]);
-                        intervalMap.Values[index].Populate(batch.key.col[i], batch, i, batch.hash.col[i], vother[i] - ((vother[i] - offset) % progress));
-                        endPointHeap.Insert(temp - ((temp - (offset + width)) % skip), index);
+                        var temp = Math.Max(vsync[i] + this.skip - 1, vother[i] + this.width);
+                        int index = this.intervalMap.Insert(batch.hash.col[i]);
+                        this.intervalMap.Values[index].Populate(batch.key.col[i], batch, i, batch.hash.col[i], vother[i] - ((vother[i] - this.offset) % this.progress + this.progress) % this.progress);
+                        this.endPointHeap.Insert(temp - ((temp - (this.offset + this.width)) % this.skip + this.skip) % this.skip, index);
                     }
                 }
                 else if (vother[i] == long.MinValue) // Punctuation
                 {
-                    if (vsync[i] > lastSyncTime) ReachTime(vsync[i]);
+                    if (vsync[i] > this.lastSyncTime) ReachTime(vsync[i]);
 
-                    int ind = output.Count++;
-                    output.vsync.col[ind] = vsync[i] - ((vsync[i] - offset) % progress);
-                    output.vother.col[ind] = long.MinValue;
-                    output.key.col[ind] = default;
-                    output[ind] = default;
-                    output.hash.col[ind] = batch.hash.col[i];
-                    output.bitvector.col[ind >> 6] |= (1L << (ind & 0x3f));
-                    if (output.Count == Config.DataBatchSize) FlushContents();
+                    int ind = this.output.Count++;
+                    this.output.vsync.col[ind] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
+                    this.output.vother.col[ind] = long.MinValue;
+                    this.output.key.col[ind] = batch.key.col[i];
+                    this.output.payload.col[ind] = default;
+                    this.output.hash.col[ind] = batch.hash.col[i];
+                    this.output.bitvector.col[ind >> 6] |= (1L << (ind & 0x3f));
+                    if (this.output.Count == Config.DataBatchSize) FlushContents();
                 }
             }
         }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/StatelessQuantizeLifetimePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/QuantizeLifetime/StatelessQuantizeLifetimePipe.cs
@@ -58,24 +58,24 @@ namespace Microsoft.StreamProcessing
                     {
                         if (vother[i] == StreamEvent.InfinitySyncTime) // start edge
                         {
-                            vsync[i] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                            vsync[i] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                         }
                         else if (vother[i] < vsync[i]) // end edge
                         {
                             var temp = Math.Max(vsync[i] + this.skip - 1, vother[i] + this.width);
-                            vsync[i] = temp - ((temp - (this.offset + this.width)) % this.skip);
-                            vother[i] = vother[i] - ((vother[i] - this.offset) % this.progress);
+                            vsync[i] = temp - ((temp - (this.offset + this.width)) % this.skip + this.skip) % this.skip;
+                            vother[i] = vother[i] - ((vother[i] - this.offset) % this.progress + this.progress) % this.progress;
                         }
                         else // interval
                         {
                             var temp = Math.Max(vother[i] + this.skip - 1, vsync[i] + this.width);
-                            vother[i] = temp - ((temp - (this.offset + this.width)) % this.skip);
-                            vsync[i] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                            vother[i] = temp - ((temp - (this.offset + this.width)) % this.skip + this.skip) % this.skip;
+                            vsync[i] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                         }
                     }
                     else if (vother[i] == long.MinValue) // Punctuation
                     {
-                        vsync[i] = vsync[i] - ((vsync[i] - this.offset) % this.progress);
+                        vsync[i] = vsync[i] - ((vsync[i] - this.offset) % this.progress + this.progress) % this.progress;
                     }
                 }
             }

--- a/Sources/Test/SimpleTesting/QuantizeLifetimeTests.cs
+++ b/Sources/Test/SimpleTesting/QuantizeLifetimeTests.cs
@@ -1,0 +1,1279 @@
+﻿// *********************************************************************
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License
+// *********************************************************************
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using Microsoft.StreamProcessing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SimpleTesting
+{
+
+    [TestClass]
+    public class QuantizeLifetimeTestsRow : TestWithConfigSettingsAndMemoryLeakDetection
+    {
+        public QuantizeLifetimeTestsRow() : base(
+            new ConfigModifier()
+            .ForceRowBasedExecution(true)
+            .DontFallBackToRowBasedExecution(true)
+            .MapArity(1)
+            .ReduceArity(1))
+        { }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPassthroughRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPointsRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPointsStatelessRow()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingConsecutiveRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingProgressiveRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPassthroughRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPointsRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPointsStatelessRow()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingConsecutiveRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingProgressiveRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPassthroughRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPointsRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPointsStatelessRow()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetConsecutiveRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetProgressiveRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPassthroughRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPointsRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPointsStatelessRow()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetConsecutiveRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetProgressiveRow()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+    }
+
+    [TestClass]
+    public class QuantizeLifetimeTestsRowSmallBatch : TestWithConfigSettingsAndMemoryLeakDetection
+    {
+        public QuantizeLifetimeTestsRowSmallBatch() : base(
+            new ConfigModifier()
+            .ForceRowBasedExecution(true)
+            .DontFallBackToRowBasedExecution(true)
+            .DataBatchSize(100)
+            .MapArity(1)
+            .ReduceArity(1))
+        { }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPassthroughRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPointsRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPointsStatelessRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingConsecutiveRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingProgressiveRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPassthroughRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPointsRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPointsStatelessRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingConsecutiveRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingProgressiveRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPassthroughRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPointsRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPointsStatelessRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetConsecutiveRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetProgressiveRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPassthroughRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPointsRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPointsStatelessRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetConsecutiveRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetProgressiveRowSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+    }
+
+    [TestClass]
+    public class QuantizeLifetimeTestsColumnar : TestWithConfigSettingsAndMemoryLeakDetection
+    {
+        public QuantizeLifetimeTestsColumnar() : base(
+            new ConfigModifier()
+            .ForceRowBasedExecution(false)
+            .DontFallBackToRowBasedExecution(true)
+            .MapArity(1)
+            .ReduceArity(1))
+        { }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPassthroughColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPointsColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPointsStatelessColumnar()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingConsecutiveColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingProgressiveColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPassthroughColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPointsColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPointsStatelessColumnar()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingConsecutiveColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingProgressiveColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPassthroughColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPointsColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPointsStatelessColumnar()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetConsecutiveColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetProgressiveColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPassthroughColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPointsColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPointsStatelessColumnar()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetConsecutiveColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetProgressiveColumnar()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+    }
+
+    [TestClass]
+    public class QuantizeLifetimeTestsColumnarSmallBatch : TestWithConfigSettingsAndMemoryLeakDetection
+    {
+        public QuantizeLifetimeTestsColumnarSmallBatch() : base(
+            new ConfigModifier()
+            .ForceRowBasedExecution(false)
+            .DontFallBackToRowBasedExecution(true)
+            .DataBatchSize(100)
+            .MapArity(1)
+            .ReduceArity(1))
+        { }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPassthroughColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPointsColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPointsStatelessColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingConsecutiveColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingProgressiveColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPassthroughColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPointsColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPointsStatelessColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingConsecutiveColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingProgressiveColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPassthroughColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPointsColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPointsStatelessColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetConsecutiveColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetProgressiveColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPassthroughColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPointsColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPointsStatelessColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetConsecutiveColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetProgressiveColumnarSmallBatch()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+    }
+}

--- a/Sources/Test/SimpleTesting/QuantizeLifetimeTests.tt
+++ b/Sources/Test/SimpleTesting/QuantizeLifetimeTests.tt
@@ -1,0 +1,354 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+// *********************************************************************
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License
+// *********************************************************************
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using Microsoft.StreamProcessing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SimpleTesting
+{
+<#
+foreach (var orientation in new [] { "Row", "Columnar" })
+foreach (var batch in new [] { string.Empty, "SmallBatch" })
+{
+    var suffix = orientation + batch;
+#>
+
+    [TestClass]
+    public class QuantizeLifetimeTests<#= suffix #> : TestWithConfigSettingsAndMemoryLeakDetection
+    {
+        public QuantizeLifetimeTests<#= suffix #>() : base(
+            new ConfigModifier()
+<#  switch (orientation)
+    {
+        case "Row": #>
+            .ForceRowBasedExecution(true)
+            .DontFallBackToRowBasedExecution(true)
+<#          break;
+        case "Columnar": #>
+            .ForceRowBasedExecution(false)
+            .DontFallBackToRowBasedExecution(true)
+<#          break;
+    } #>
+<# if (!string.IsNullOrEmpty(batch)) { #>
+            .DataBatchSize(100)
+<# } #>
+            .MapArity(1)
+            .ReduceArity(1))
+        { }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPassthrough<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPoints<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingPointsStateless<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 10, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingConsecutive<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingProgressive<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPassthrough<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPoints<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingPointsStateless<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10, o * 10 + 100, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10, o => o * 10 + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingConsecutive<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 10), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingProgressive<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - (o % 5), o - (o % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPassthrough<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPoints<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetPointsStateless<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 15, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetConsecutive<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(10, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeTumblingOffsetProgressive<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 10, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(10, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPassthrough<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(input));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPoints<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o * 10 + 5, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetPointsStateless<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000).Select(o => (long)o);
+
+            var expected = Enumerable.Range(0, 50000).Select(o => (long)o)
+                .Select(o => StreamEvent.CreateInterval(o * 10 + 5, o * 10 + 105, o));
+
+            var inputStream = input.ToObservable().ToTemporalStreamable(o => o * 10 + 5, o => (o * 10 + 5) + 1);
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetConsecutive<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 10), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.QuantizeLifetime(100, 10, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void QuantizeLifetimeHoppingOffsetProgressive<#= suffix #>()
+        {
+            var input = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreatePoint(o, o));
+
+            var expected = Enumerable.Range(0, 50000)
+                .Select(o => StreamEvent.CreateInterval(o - ((o + 5) % 5), o - ((o + 5) % 10) + 100, o));
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var outputStream = inputStream.ProgressiveQuantizeLifetime(100, 10, 5, 5);
+            var output = outputStream.ToStreamEventObservable().Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(output.SequenceEqual(expected));
+        }
+    }
+<# } #>
+}

--- a/Sources/Test/SimpleTesting/SimpleTesting.csproj
+++ b/Sources/Test/SimpleTesting/SimpleTesting.csproj
@@ -83,6 +83,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>JoinTests.tt</DependentUpon>
     </Compile>
+    <Compile Include="QuantizeLifetimeTests.cs">
+      <DependentUpon>QuantizeLifetimeTests.tt</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
     <Compile Include="LeftOuterJoinTests.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -177,6 +182,10 @@
     <Content Include="JoinTests.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>JoinTests.cs</LastGenOutput>
+    </Content>
+    <Content Include="QuantizeLifetimeTests.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>QuantizeLifetimeTests.cs</LastGenOutput>
     </Content>
     <Content Include="LeftOuterJoinTests.tt">
       <Generator>TextTemplatingFileGenerator</Generator>


### PR DESCRIPTION
Implement progressive quantize lifetime feature:
- Edit the logic for the quantize operator to use the "hop" size to quantize the end edges, and the "progress" size to quantize the start edges
- Add tests over the operator, and fix an oversight in the columnar implementation regarding accessing an internal class from generated code
- Fix an issue in the Quantize operator for time values less than zero (why must the % operator not be a proper mathematical modulus?!)