### PR TITLE
Fix performance test zero output

### DIFF
--- a/Sources/Test/TrillPerf/Streamables/EquiJoinStreamablePerfTest.cs
+++ b/Sources/Test/TrillPerf/Streamables/EquiJoinStreamablePerfTest.cs
@@ -60,14 +60,9 @@ namespace PerformanceTesting.Streamables
                 }
             }
 
-            if (batch.Count > 0)
-            {
-                batches.Add(batch);
-            }
-
             // Add last CTI of infinity.
-            // TODO: inline this punctuation
-            // batches.Add(new StreamMessage<Empty, int>(StreamMessageKind.Punctuation, DateTimeOffset.MaxValue.UtcTicks));
+            batch.AddPunctuation(StreamEvent.InfinitySyncTime);
+            batches.Add(batch);
 
             // Convert to IStreamable.
             return batches.ToObservable().CreateStreamable();


### PR DESCRIPTION
The Trill performance test relied on a punctuation that was at some point removed, which resulted in zero output being produced. This change adds the punctuation back.