### PR TITLE
Fix Perf Test reference count issue

### DIFF
--- a/Sources/Test/TrillPerf/Streamables/EquiJoinStreamablePerfTest.cs
+++ b/Sources/Test/TrillPerf/Streamables/EquiJoinStreamablePerfTest.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License
 // *********************************************************************
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reactive.Linq;
@@ -16,24 +15,31 @@ namespace PerformanceTesting.Streamables
         [PerfTest("EquiJoinStreamable")]
         public static void EquiJoinStreamableTest(IPerfTestState state)
         {
-            const int LeftSize = 1000000;
+            const int LeftSize = 1_000_000;
             const int GroupingSize = 10;
             const int RightSize = LeftSize * GroupingSize;
             const int NumTests = 20;
             var pool = new MemoryPool<Empty, int>();
 
             state.Action = "creating input data...";
-            var input1 = CreateSequentialStreamable(LeftSize, pool);
-            var input2 = CreateSequentialStreamable(RightSize, pool);
+            var leftInputData = CreateInputData(LeftSize, pool);
+            var rightInputData = CreateInputData(RightSize, pool);
 
             for (int j = 1; j <= NumTests; j++)
             {
                 state.Action = string.Format("running {0}/{1}...", j, NumTests);
 
+                // Clone input sources to new streamables for this iteration's query
+                var leftInputStreamable = CloneInputToStreamable(leftInputData);
+                var rightInputStreamable = CloneInputToStreamable(rightInputData);
+
+                // Setup query
+                var output = leftInputStreamable.Join(rightInputStreamable, l => l, r => r / GroupingSize, (l, r) => l);
+                int outputCount = 0;
+
+                // Process Data
                 var timer = new Stopwatch();
                 timer.Start();
-                var output = input1.Join(input2, l => l, r => r / GroupingSize, (l, r) => l);
-                int outputCount = 0;
                 output.ToStreamMessageObservable().ForEachAsync(b => outputCount += b.Count).Wait();
                 timer.Stop();
 
@@ -43,7 +49,7 @@ namespace PerformanceTesting.Streamables
             state.Action = "DONE";
         }
 
-        private static IStreamable<Empty, int> CreateSequentialStreamable(int length, MemoryPool<Empty, int> pool)
+        private static List<StreamMessage<Empty, int>> CreateInputData(int length, MemoryPool<Empty, int> pool)
         {
             // Construct event batches from input.
             var batches = new List<StreamMessage<Empty, int>>();
@@ -51,7 +57,7 @@ namespace PerformanceTesting.Streamables
             batch.Allocate();
             for (int i = 0; i < length; i++)
             {
-                batch.Add(0, DateTimeOffset.MaxValue.UtcTicks, Empty.Default, i);
+                batch.Add(0, StreamEvent.InfinitySyncTime, Empty.Default, i);
                 if (batch.Count == Config.DataBatchSize)
                 {
                     batches.Add(batch);
@@ -65,6 +71,18 @@ namespace PerformanceTesting.Streamables
             batches.Add(batch);
 
             // Convert to IStreamable.
+            return batches;
+        }
+
+        private static IStreamable<Empty, int> CloneInputToStreamable(List<StreamMessage<Empty, int>> inputSequence)
+        {
+            var batches = new List<StreamMessage<Empty, int>>();
+            foreach (var inputBatch in inputSequence)
+            {
+                var batch = StreamMessageManager.GetStreamMessage(inputBatch.memPool);
+                batch.CloneFrom(inputBatch);
+                batches.Add(batch);
+            }
             return batches.ToObservable().CreateStreamable();
         }
     }

--- a/Sources/Test/TrillPerf/Streamables/EquiJoinStreamablePerfTest.cs
+++ b/Sources/Test/TrillPerf/Streamables/EquiJoinStreamablePerfTest.cs
@@ -70,12 +70,12 @@ namespace PerformanceTesting.Streamables
             batch.AddPunctuation(StreamEvent.InfinitySyncTime);
             batches.Add(batch);
 
-            // Convert to IStreamable.
             return batches;
         }
 
         private static IStreamable<Empty, int> CloneInputToStreamable(List<StreamMessage<Empty, int>> inputSequence)
         {
+            // Clone each batch in the input sequence
             var batches = new List<StreamMessage<Empty, int>>();
             foreach (var inputBatch in inputSequence)
             {
@@ -83,6 +83,8 @@ namespace PerformanceTesting.Streamables
                 batch.CloneFrom(inputBatch);
                 batches.Add(batch);
             }
+
+            // Convert the batches to IStreamable.
             return batches.ToObservable().CreateStreamable();
         }
     }


### PR DESCRIPTION
Currently, the perf test uses StreamMessage for many iterations of a single test, but after the first test, these batches are returned to the memory pool, leading to unpredictable results. The fix is to clone the batches, which increment their ref count at each iteration.