### PR TITLE
Fixing FileStream Ingress/Egress

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Egress/Binary/BinaryStreamObserver.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Egress/Binary/BinaryStreamObserver.cs
@@ -15,7 +15,8 @@ namespace Microsoft.StreamProcessing
 
         public BinaryStreamObserver(StreamProperties<TKey, TPayload> streamProperties, Stream stream)
         {
-            this.serializer = StreamableSerializer.Create<QueuedMessage<StreamMessage<TKey, TPayload>>>(new SerializerSettings());
+            this.serializer = StreamableSerializer.Create<QueuedMessage<StreamMessage<TKey, TPayload>>>(
+                new SerializerSettings() { KnownTypes = StreamMessageManager.GeneratedTypes() });
             this.stream = stream;
         }
 


### PR DESCRIPTION
Fixing a few issues:
- On an OnCompleted StreamMessage, BinaryIngressReader was passing the null Message field to its observer, causing an AV. This should instead call observer.OnCompleted().
- For Columnar, BinaryIngressReader (Ingress) and BinaryStreamObserver (Egress) were not passing the generated StreamMessage subtypes to their serializers, which caused the message to be de/serialized as the base StreamMessage type. Passing StreamMessageManager.GeneratedTypes() to both fixes the issue.