### PR TITLE
Remove calls to Fx string hash code in favor of a consistent one

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Collections/CacheKey.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Collections/CacheKey.cs
@@ -37,10 +37,7 @@ namespace Microsoft.StreamProcessing.Internal.Collections
     {
         private T keyData;
 
-        public CacheKey(T keyData)
-        {
-            this.keyData = keyData;
-        }
+        public CacheKey(T keyData) => this.keyData = keyData;
 
         public override int GetHashCode() => this.keyData.GetHashCode() ^ this.batchSize ^ this.useMultiString.GetHashCode();
 

--- a/Sources/Core/Microsoft.StreamProcessing/Collections/StreamMessage.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Collections/StreamMessage.cs
@@ -108,6 +108,16 @@ namespace Microsoft.StreamProcessing
         /// <summary>
         /// Currently for internal use only - do not use directly.
         /// </summary>
+        protected static readonly Func<TKey, int> HashCode = EqualityComparerExpression<TKey>.DefaultGetHashCodeFunction;
+
+        /// <summary>
+        /// Currently for internal use only - do not use directly.
+        /// </summary>
+        protected static readonly bool IsPartitioned = typeof(TKey) != typeof(Empty);
+
+        /// <summary>
+        /// Currently for internal use only - do not use directly.
+        /// </summary>
         // Fields used by data batches
         [DataMember]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -226,7 +236,7 @@ namespace Microsoft.StreamProcessing
             this.vother.col[this.Count] = vother;
             if (this.key != null) this.key.col[this.Count] = key;
             if (this.payload != null) this.payload.col[this.Count] = payload;
-            this.hash.col[this.Count] = key.GetHashCode();
+            this.hash.col[this.Count] = IsPartitioned ? HashCode(key) : 0;
             this.Count++;
             return this.Count == this.vsync.col.Length;
         }
@@ -373,7 +383,7 @@ namespace Microsoft.StreamProcessing
                         vother[count] = largeBatch.Array[localOffset].OtherTime;
                         this.payload.col[count] = largeBatch.Array[localOffset].Payload;
                         this.key.col[count] = partitionConstructor(largeBatch.Array[localOffset].PartitionKey);
-                        this.hash.col[count] = this.key.col[count].GetHashCode();
+                        this.hash.col[count] = HashCode(this.key.col[count]);
                         if (largeBatch.Array[localOffset].OtherTime < 0)
                         {
                             this.bitvector.col[count >> 6] |= (1L << (count & 0x3f));
@@ -431,8 +441,9 @@ namespace Microsoft.StreamProcessing
                         vsync[count] = start;
                         vother[count] = StreamEvent.InfinitySyncTime;
                         this.payload.col[count] = largeBatch.Array[localOffset];
-                        this.key.col[count] = partitionConstructor(partition);
-                        this.hash.col[count] = partition.GetHashCode();
+                        var p = partitionConstructor(partition);
+                        this.key.col[count] = p;
+                        this.hash.col[count] = HashCode(p);
                         localOffset++;
                         count++;
                     }
@@ -488,8 +499,9 @@ namespace Microsoft.StreamProcessing
                         vsync[count] = start;
                         vother[count] = endEdgeExtractor(largeBatch.Array[localOffset]);
                         this.payload.col[count] = largeBatch.Array[localOffset];
-                        this.key.col[count] = partitionConstructor(partition);
-                        this.hash.col[count] = partition.GetHashCode();
+                        var p = partitionConstructor(partition);
+                        this.key.col[count] = p;
+                        this.hash.col[count] = HashCode(p);
                         localOffset++;
                         count++;
                     }
@@ -947,17 +959,15 @@ namespace Microsoft.StreamProcessing
             }
         }
 
+        // I check for 0 because I'm betting in most cases the vectors are 0
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe int CalculateHammingWeight(ulong bitVectorLong, byte* sixteenBitHammingWeights)
-        {
-            // I check for 0 because I'm betting in most cases the vectors are 0
-            return bitVectorLong > 0
+            => bitVectorLong > 0
                        ? sixteenBitHammingWeights[bitVectorLong & 0xFFFF]
                          + sixteenBitHammingWeights[bitVectorLong >> 16 & 0xFFFF]
                          + sixteenBitHammingWeights[bitVectorLong >> 32 & 0xFFFF]
                          + sixteenBitHammingWeights[bitVectorLong >> 48]
                        : 0;
-        }
 
         /// <summary>
         /// Currently for internal use only - do not use directly.

--- a/Sources/Core/Microsoft.StreamProcessing/Ingress/SubscriptionBase.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Ingress/SubscriptionBase.cs
@@ -1344,13 +1344,8 @@ namespace Microsoft.StreamProcessing.Internal
             }
 
             var count = this.currentBatch.Count;
-            this.currentBatch.vsync.col[count] = value.SyncTime;
-            this.currentBatch.vother.col[count] = value.OtherTime;
+            this.currentBatch.Add(value.SyncTime, value.OtherTime, new PartitionKey<TKey>(value.PartitionKey), default);
             this.currentBatch.bitvector.col[count >> 6] |= (1L << (count & 0x3f));
-            this.currentBatch.key.col[count] = new PartitionKey<TKey>(value.PartitionKey);
-            this.currentBatch.hash.col[count] = value.PartitionKey.GetHashCode();
-            this.currentBatch[count] = default;
-            this.currentBatch.Count = count + 1;
             if (this.currentBatch.Count == Config.DataBatchSize)
             {
                 if (this.flushPolicy == PartitionedFlushPolicy.FlushOnBatchBoundary) OnFlush();
@@ -1895,13 +1890,8 @@ namespace Microsoft.StreamProcessing.Internal
             }
 
             var count = this.currentBatch.Count;
-            this.currentBatch.vsync.col[count] = value.SyncTime;
-            this.currentBatch.vother.col[count] = value.OtherTime;
+            this.currentBatch.Add(value.SyncTime, value.OtherTime, new PartitionKey<TKey>(value.PartitionKey), default);
             this.currentBatch.bitvector.col[count >> 6] |= (1L << (count & 0x3f));
-            this.currentBatch.key.col[count] = new PartitionKey<TKey>(value.PartitionKey);
-            this.currentBatch.hash.col[count] = value.PartitionKey.GetHashCode();
-            this.currentBatch[count] = default;
-            this.currentBatch.Count = count + 1;
             if (this.currentBatch.Count == Config.DataBatchSize)
             {
                 if (this.flushPolicy == PartitionedFlushPolicy.FlushOnBatchBoundary) OnFlush();

--- a/Sources/Core/Microsoft.StreamProcessing/Ingress/SubscriptionBase.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Ingress/SubscriptionBase.tt
@@ -415,13 +415,8 @@ foreach (bool disordered in new[] { true, false })
             }
 
             var count = this.currentBatch.Count;
-            this.currentBatch.vsync.col[count] = value.SyncTime;
-            this.currentBatch.vother.col[count] = value.OtherTime;
+            this.currentBatch.Add(value.SyncTime, value.OtherTime, new PartitionKey<TKey>(value.PartitionKey), default);
             this.currentBatch.bitvector.col[count >> 6] |= (1L << (count & 0x3f));
-            this.currentBatch.key.col[count] = new PartitionKey<TKey>(value.PartitionKey);
-            this.currentBatch.hash.col[count] = value.PartitionKey.GetHashCode();
-            this.currentBatch[count] = default;
-            this.currentBatch.Count = count + 1;
             if (this.currentBatch.Count == Config.DataBatchSize)
             {
                 if (this.flushPolicy == PartitionedFlushPolicy.FlushOnBatchBoundary) OnFlush();

--- a/Sources/Core/Microsoft.StreamProcessing/Ingress/Temporal/TemporalIngressTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Ingress/Temporal/TemporalIngressTemplate.cs
@@ -57,7 +57,7 @@ namespace Microsoft.StreamProcessing
                     "ections;\r\n\r\n");
   bool partitioned = (partitionString == "Partitioned");
     string baseStructure = partitionString + "StreamEvent<" + adjustedGenericArgs + ">";
-    string globalPunctuation= partitioned ? "LowWatermark" : "Punctuation";
+    string globalPunctuation = partitioned ? "LowWatermark" : "Punctuation";
     string highWatermark = partitioned ? "partitionHighWatermarks[value.PartitionKey]" : "highWatermark";
     string keyType = !partitioned ? "Microsoft.StreamProcessing.Empty" : "PartitionKey<TKey>";
     string streamEventFromValue = fusionOption == "Disordered" ? ("new " + partitionString + "StreamEvent<" + genericArguments + ">(" + (!partitioned ? string.Empty : "value.PartitionKey, ") + "value.SyncTime, value.OtherTime, default)") : "value";
@@ -78,7 +78,12 @@ namespace Microsoft.StreamProcessing
             this.Write(this.ToStringHelper.ToStringWithCulture(TResult));
             this.Write(">\r\n{\r\n    ");
             this.Write(this.ToStringHelper.ToStringWithCulture(staticCtor));
-            this.Write("\r\n\r\n    public ");
+            this.Write("\r\n");
+  if (partitioned) { 
+            this.Write("    private static readonly Func<TKey, int> GetHashCode = EqualityComparerExpress" +
+                    "ion<TKey>.DefaultGetHashCodeFunction;\r\n");
+  } 
+            this.Write("\r\n    public ");
             this.Write(this.ToStringHelper.ToStringWithCulture(className));
             this.Write("() { }\r\n\r\n    public ");
             this.Write(this.ToStringHelper.ToStringWithCulture(className));
@@ -102,11 +107,11 @@ namespace Microsoft.StreamProcessing
             this.Write(this.ToStringHelper.ToStringWithCulture(partitionString));
             this.Write("StreamEvent<");
             this.Write(this.ToStringHelper.ToStringWithCulture(genericArguments));
-            this.Write(">> diagnosticOutput)\r\n        : base(observable,\r\n                identifier,\r\n  " +
-                    "              streamable,\r\n                observer,\r\n                disorderPo" +
-                    "licy,\r\n                flushPolicy,\r\n                punctuationPolicy,\r\n");
+            this.Write(">> diagnosticOutput)\r\n            : base(observable,\r\n                identifier," +
+                    "\r\n                streamable,\r\n                observer,\r\n                disord" +
+                    "erPolicy,\r\n                flushPolicy,\r\n                punctuationPolicy,\r\n");
   if (partitioned) { 
-            this.Write("                    lowWatermarkPolicy,\r\n");
+            this.Write("                lowWatermarkPolicy,\r\n");
   } 
             this.Write("                onCompletedPolicy,\r\n                diagnosticOutput)\r\n    {\r\n   " +
                     "     ");
@@ -784,7 +789,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(emptyOrPartition));
 
 this.Write(";\r\n    currentBatch.hash.col[count] = ");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(partitionString == "Partitioned" ? "value.PartitionKey.GetHashCode()" : "0"));
+this.Write(this.ToStringHelper.ToStringWithCulture(partitionString == "Partitioned" ? "GetHashCode(value.PartitionKey)" : "0"));
 
 this.Write(";\r\n");
 

--- a/Sources/Core/Microsoft.StreamProcessing/Ingress/Temporal/TemporalIngressTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Ingress/Temporal/TemporalIngressTemplate.tt
@@ -54,7 +54,7 @@ using Microsoft.StreamProcessing.Internal.Collections;
 
 <#  bool partitioned = (partitionString == "Partitioned");
     string baseStructure = partitionString + "StreamEvent<" + adjustedGenericArgs + ">";
-    string globalPunctuation= partitioned ? "LowWatermark" : "Punctuation";
+    string globalPunctuation = partitioned ? "LowWatermark" : "Punctuation";
     string highWatermark = partitioned ? "partitionHighWatermarks[value.PartitionKey]" : "highWatermark";
     string keyType = !partitioned ? "Microsoft.StreamProcessing.Empty" : "PartitionKey<TKey>";
     string streamEventFromValue = fusionOption == "Disordered" ? ("new " + partitionString + "StreamEvent<" + genericArguments + ">(" + (!partitioned ? string.Empty : "value.PartitionKey, ") + "value.SyncTime, value.OtherTime, default)") : "value";
@@ -64,6 +64,9 @@ using Microsoft.StreamProcessing.Internal.Collections;
 internal sealed class <#= className #><#= genericParameters #> : <#= partitionString #><#= fusionOption == "Disordered" ? "Disordered" : string.Empty #>ObserverSubscriptionBase<<#= keyOrNothing #><#= inheritBase #>, <#= TPayload #>, <#= TResult #>>
 {
     <#= staticCtor #>
+<#  if (partitioned) { #>
+    private static readonly Func<TKey, int> GetHashCode = EqualityComparerExpression<TKey>.DefaultGetHashCodeFunction;
+<#  } #>
 
     public <#= className #>() { }
 
@@ -80,7 +83,7 @@ internal sealed class <#= className #><#= genericParameters #> : <#= partitionSt
 <#  } #>
         OnCompletedPolicy onCompletedPolicy,
         IObserver<OutOfOrder<#= partitionString #>StreamEvent<<#= genericArguments #>>> diagnosticOutput)
-        : base(observable,
+            : base(observable,
                 identifier,
                 streamable,
                 observer,
@@ -88,7 +91,7 @@ internal sealed class <#= className #><#= genericParameters #> : <#= partitionSt
                 flushPolicy,
                 punctuationPolicy,
 <#  if (partitioned) { #>
-                    lowWatermarkPolicy,
+                lowWatermarkPolicy,
 <#  } #>
                 onCompletedPolicy,
                 diagnosticOutput)
@@ -672,7 +675,7 @@ private void AddToGeneratedBatch()
     currentBatch.vsync.col[count] = value.SyncTime;
     currentBatch.vother.col[count] = <#= generatedEndTimeVariable #>;
     currentBatch.key.col[count] = <#= emptyOrPartition #>;
-    currentBatch.hash.col[count] = <#= partitionString == "Partitioned" ? "value.PartitionKey.GetHashCode()" : "0" #>;
+    currentBatch.hash.col[count] = <#= partitionString == "Partitioned" ? "GetHashCode(value.PartitionKey)" : "0" #>;
 <#+ if (resultRepresentation.noFields)
     { #>
     generatedBatch.payload.col[count] = <#= valueString #>;

--- a/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="2.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="2.10.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Group/GroupPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Group/GroupPipe.cs
@@ -11,286 +11,286 @@ using Microsoft.StreamProcessing.Internal.Collections;
 namespace Microsoft.StreamProcessing
 {
 
-        [DataContract]
-        internal sealed class PartitionedGroupNestedPipe<TOuterKey, TSource, TInnerKey> :
-            Pipe<CompoundGroupKey<TOuterKey, TInnerKey>, TSource>, IStreamObserver<TOuterKey, TSource>
+    [DataContract]
+    internal sealed class PartitionedGroupNestedPipe<TOuterKey, TSource, TInnerKey> :
+        Pipe<CompoundGroupKey<TOuterKey, TInnerKey>, TSource>, IStreamObserver<TOuterKey, TSource>
+    {
+        [SchemaSerialization]
+        private readonly Expression<Func<TSource, TInnerKey>> keySelector;
+        private readonly Func<TSource, TInnerKey> keySelectorFunc;
+        [SchemaSerialization]
+        private readonly Expression<Func<TInnerKey, int>> keyComparer;
+        private readonly Func<TInnerKey, int> innerHashCode;
+
+        private readonly MemoryPool<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> l1Pool;
+        private readonly string errorMessages;
+
+        [Obsolete("Used only by serialization. Do not call directly.")]
+        public PartitionedGroupNestedPipe() { }
+
+        public PartitionedGroupNestedPipe(
+            GroupNestedStreamable<TOuterKey, TSource, TInnerKey> stream,
+            IStreamObserver<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> observer)
+            : base(stream, observer)
         {
-            [SchemaSerialization]
-            private readonly Expression<Func<TSource, TInnerKey>> keySelector;
-            private readonly Func<TSource, TInnerKey> keySelectorFunc;
-            [SchemaSerialization]
-            private readonly Expression<Func<TInnerKey, int>> keyComparer;
-            private readonly Func<TInnerKey, int> innerHashCode;
+            this.keySelector = stream.KeySelector;
+            this.keySelectorFunc = this.keySelector.Compile();
+            this.keyComparer = ((CompoundGroupKeyEqualityComparer<TOuterKey, TInnerKey>)stream.Properties.KeyEqualityComparer).innerComparer.GetGetHashCodeExpr();
+            this.innerHashCode = this.keyComparer.Compile();
 
-            private readonly MemoryPool<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> l1Pool;
-            private readonly string errorMessages;
+            this.errorMessages = stream.ErrorMessages;
+            this.l1Pool = MemoryManager.GetMemoryPool<CompoundGroupKey<TOuterKey, TInnerKey>, TSource>(stream.Properties.IsColumnar);
+        }
 
-            [Obsolete("Used only by serialization. Do not call directly.")]
-            public PartitionedGroupNestedPipe() { }
+        public unsafe void OnNext(StreamMessage<TOuterKey, TSource> batch)
+        {
+            this.l1Pool.Get(out StreamMessage<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> outputBatch);
+            outputBatch.vsync = batch.vsync;
+            outputBatch.vother = batch.vother;
+            outputBatch.payload = batch.payload;
+            outputBatch.hash = batch.hash.MakeWritable(this.l1Pool.intPool);
+            outputBatch.bitvector = batch.bitvector;
+            this.l1Pool.GetKey(out outputBatch.key);
 
-            public PartitionedGroupNestedPipe(
-                GroupNestedStreamable<TOuterKey, TSource, TInnerKey> stream,
-                IStreamObserver<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> observer)
-                : base(stream, observer)
+            outputBatch.Count = batch.Count;
+
+            var count = batch.Count;
+
+            var srckey = batch.key.col;
+            var destkey = outputBatch.key.col;
+            var destpayload = outputBatch;
+            fixed (long* srcbv = batch.bitvector.col)
             {
-                this.keySelector = stream.KeySelector;
-                this.keySelectorFunc = this.keySelector.Compile();
-                this.keyComparer = ((CompoundGroupKeyEqualityComparer<TOuterKey, TInnerKey>)stream.Properties.KeyEqualityComparer).innerComparer.GetGetHashCodeExpr();
-                this.innerHashCode = this.keyComparer.Compile();
-
-                this.errorMessages = stream.ErrorMessages;
-                this.l1Pool = MemoryManager.GetMemoryPool<CompoundGroupKey<TOuterKey, TInnerKey>, TSource>(stream.Properties.IsColumnar);
-            }
-
-            public unsafe void OnNext(StreamMessage<TOuterKey, TSource> batch)
-            {
-                this.l1Pool.Get(out StreamMessage<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> outputBatch);
-                outputBatch.vsync = batch.vsync;
-                outputBatch.vother = batch.vother;
-                outputBatch.payload = batch.payload;
-                outputBatch.hash = batch.hash.MakeWritable(this.l1Pool.intPool);
-                outputBatch.bitvector = batch.bitvector;
-                this.l1Pool.GetKey(out outputBatch.key);
-
-                outputBatch.Count = batch.Count;
-
-                var count = batch.Count;
-
-                var srckey = batch.key.col;
-                var destkey = outputBatch.key.col;
-                var destpayload = outputBatch;
-                fixed (long* srcbv = batch.bitvector.col)
+                fixed (int* desthash = outputBatch.hash.col)
                 {
-                    fixed (int* desthash = outputBatch.hash.col)
+                    for (int i = 0; i < count; i++)
                     {
-                        for (int i = 0; i < count; i++)
+                        if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0)
                         {
-                            if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0)
+                            if (batch.vother.col[i] == long.MinValue)
                             {
-                                if (batch.vother.col[i] == long.MinValue)
-                                {
-                                    destkey[i].outerGroup = srckey[i];
-                                    destkey[i].innerGroup = default;
-                                    desthash[i] = batch.hash.col[i];
-                                    outputBatch.bitvector.col[i >> 6] |= (1L << (i & 0x3f));
-                                }
-                                continue;
+                                destkey[i].outerGroup = srckey[i];
+                                destkey[i].innerGroup = default;
+                                desthash[i] = batch.hash.col[i];
+                                outputBatch.bitvector.col[i >> 6] |= (1L << (i & 0x3f));
                             }
-                            var key = this.keySelectorFunc(destpayload[i]);
-                            var innerHash = this.innerHashCode(key);
-                            var hash = desthash[i] ^ innerHash;
-
-                            destkey[i].outerGroup = srckey[i];
-                            destkey[i].innerGroup = key;
-                            destkey[i].hashCode = hash;
-                            desthash[i] = hash;
+                            continue;
                         }
+                        var key = this.keySelectorFunc(destpayload[i]);
+                        var innerHash = this.innerHashCode(key);
+                        var hash = desthash[i] ^ innerHash;
+
+                        destkey[i].outerGroup = srckey[i];
+                        destkey[i].innerGroup = key;
+                        destkey[i].hashCode = hash;
+                        desthash[i] = hash;
                     }
                 }
-
-                batch.key.Return();
-                batch.Return();
-                this.Observer.OnNext(outputBatch);
             }
 
-            public override void ProduceQueryPlan(PlanNode previous)
-            {
-                this.Observer.ProduceQueryPlan(new GroupPlanNode(
-                    previous,
-                    this,
-                    typeof(TOuterKey),
-                    typeof(CompoundGroupKey<TOuterKey, TInnerKey>),
-                    typeof(TSource),
-                    this.keySelector,
-                    int.MinValue,
-                    1,
-                    false,
-                    false,
-                    this.errorMessages));
-            }
-
-            public override int CurrentlyBufferedOutputCount => 0;
-
-            public override int CurrentlyBufferedInputCount => 0;
+            batch.key.Return();
+            batch.Return();
+            this.Observer.OnNext(outputBatch);
         }
 
-        [DataContract]
-        internal sealed class GroupNestedPipe<TOuterKey, TSource, TInnerKey> :
-            Pipe<CompoundGroupKey<TOuterKey, TInnerKey>, TSource>, IStreamObserver<TOuterKey, TSource>
+        public override void ProduceQueryPlan(PlanNode previous)
         {
-            [SchemaSerialization]
-            private readonly Expression<Func<TSource, TInnerKey>> keySelector;
-            private readonly Func<TSource, TInnerKey> keySelectorFunc;
-            [SchemaSerialization]
-            private readonly Expression<Func<TInnerKey, int>> keyComparer;
-            private readonly Func<TInnerKey, int> innerHashCode;
-
-            private readonly MemoryPool<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> l1Pool;
-            private readonly string errorMessages;
-
-            [Obsolete("Used only by serialization. Do not call directly.")]
-            public GroupNestedPipe() { }
-
-            public GroupNestedPipe(
-                GroupNestedStreamable<TOuterKey, TSource, TInnerKey> stream,
-                IStreamObserver<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> observer)
-                : base(stream, observer)
-            {
-                this.keySelector = stream.KeySelector;
-                this.keySelectorFunc = this.keySelector.Compile();
-                this.keyComparer = ((CompoundGroupKeyEqualityComparer<TOuterKey, TInnerKey>)stream.Properties.KeyEqualityComparer).innerComparer.GetGetHashCodeExpr();
-                this.innerHashCode = this.keyComparer.Compile();
-
-                this.errorMessages = stream.ErrorMessages;
-                this.l1Pool = MemoryManager.GetMemoryPool<CompoundGroupKey<TOuterKey, TInnerKey>, TSource>(stream.Properties.IsColumnar);
-            }
-
-            public unsafe void OnNext(StreamMessage<TOuterKey, TSource> batch)
-            {
-                this.l1Pool.Get(out StreamMessage<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> outputBatch);
-                outputBatch.vsync = batch.vsync;
-                outputBatch.vother = batch.vother;
-                outputBatch.payload = batch.payload;
-                outputBatch.hash = batch.hash.MakeWritable(this.l1Pool.intPool);
-                outputBatch.bitvector = batch.bitvector;
-                this.l1Pool.GetKey(out outputBatch.key);
-
-                outputBatch.Count = batch.Count;
-
-                var count = batch.Count;
-
-                var srckey = batch.key.col;
-                var destkey = outputBatch.key.col;
-                var destpayload = outputBatch;
-                fixed (long* srcbv = batch.bitvector.col)
-                {
-                    fixed (int* desthash = outputBatch.hash.col)
-                    {
-                        for (int i = 0; i < count; i++)
-                        {
-                            if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0) continue;
-                            var key = this.keySelectorFunc(destpayload[i]);
-                            var innerHash = this.innerHashCode(key);
-                            var hash = desthash[i] ^ innerHash;
-
-                            destkey[i].outerGroup = srckey[i];
-                            destkey[i].innerGroup = key;
-                            destkey[i].hashCode = hash;
-                            desthash[i] = hash;
-                        }
-                    }
-                }
-
-                batch.key.Return();
-                batch.Return();
-                this.Observer.OnNext(outputBatch);
-            }
-
-            public override void ProduceQueryPlan(PlanNode previous)
-            {
-                this.Observer.ProduceQueryPlan(new GroupPlanNode(
-                    previous,
-                    this,
-                    typeof(TOuterKey),
-                    typeof(CompoundGroupKey<TOuterKey, TInnerKey>),
-                    typeof(TSource),
-                    this.keySelector,
-                    int.MinValue,
-                    1,
-                    false,
-                    false,
-                    this.errorMessages));
-            }
-
-            public override int CurrentlyBufferedOutputCount => 0;
-
-            public override int CurrentlyBufferedInputCount => 0;
+            this.Observer.ProduceQueryPlan(new GroupPlanNode(
+                previous,
+                this,
+                typeof(TOuterKey),
+                typeof(CompoundGroupKey<TOuterKey, TInnerKey>),
+                typeof(TSource),
+                this.keySelector,
+                int.MinValue,
+                1,
+                false,
+                false,
+                this.errorMessages));
         }
 
-        [DataContract]
-        internal sealed class GroupPipe<TOuterKey, TSource, TInnerKey> :
-            Pipe<TInnerKey, TSource>, IStreamObserver<TOuterKey, TSource>
+        public override int CurrentlyBufferedOutputCount => 0;
+
+        public override int CurrentlyBufferedInputCount => 0;
+    }
+
+    [DataContract]
+    internal sealed class GroupNestedPipe<TOuterKey, TSource, TInnerKey> :
+        Pipe<CompoundGroupKey<TOuterKey, TInnerKey>, TSource>, IStreamObserver<TOuterKey, TSource>
+    {
+        [SchemaSerialization]
+        private readonly Expression<Func<TSource, TInnerKey>> keySelector;
+        private readonly Func<TSource, TInnerKey> keySelectorFunc;
+        [SchemaSerialization]
+        private readonly Expression<Func<TInnerKey, int>> keyComparer;
+        private readonly Func<TInnerKey, int> innerHashCode;
+
+        private readonly MemoryPool<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> l1Pool;
+        private readonly string errorMessages;
+
+        [Obsolete("Used only by serialization. Do not call directly.")]
+        public GroupNestedPipe() { }
+
+        public GroupNestedPipe(
+            GroupNestedStreamable<TOuterKey, TSource, TInnerKey> stream,
+            IStreamObserver<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> observer)
+            : base(stream, observer)
         {
-            [SchemaSerialization]
-            private readonly Expression<Func<TSource, TInnerKey>> keySelector;
-            private readonly Func<TSource, TInnerKey> keySelectorFunc;
-            [SchemaSerialization]
-            private readonly Expression<Func<TInnerKey, int>> keyComparer;
-            private readonly Func<TInnerKey, int> innerHashCode;
+            this.keySelector = stream.KeySelector;
+            this.keySelectorFunc = this.keySelector.Compile();
+            this.keyComparer = ((CompoundGroupKeyEqualityComparer<TOuterKey, TInnerKey>)stream.Properties.KeyEqualityComparer).innerComparer.GetGetHashCodeExpr();
+            this.innerHashCode = this.keyComparer.Compile();
 
-            private readonly MemoryPool<TInnerKey, TSource> l1Pool;
-            private readonly string errorMessages;
+            this.errorMessages = stream.ErrorMessages;
+            this.l1Pool = MemoryManager.GetMemoryPool<CompoundGroupKey<TOuterKey, TInnerKey>, TSource>(stream.Properties.IsColumnar);
+        }
 
-            [Obsolete("Used only by serialization. Do not call directly.")]
-            public GroupPipe() { }
+        public unsafe void OnNext(StreamMessage<TOuterKey, TSource> batch)
+        {
+            this.l1Pool.Get(out StreamMessage<CompoundGroupKey<TOuterKey, TInnerKey>, TSource> outputBatch);
+            outputBatch.vsync = batch.vsync;
+            outputBatch.vother = batch.vother;
+            outputBatch.payload = batch.payload;
+            outputBatch.hash = batch.hash.MakeWritable(this.l1Pool.intPool);
+            outputBatch.bitvector = batch.bitvector;
+            this.l1Pool.GetKey(out outputBatch.key);
 
-            public GroupPipe(
-                GroupStreamable<TOuterKey, TSource, TInnerKey> stream,
-                IStreamObserver<TInnerKey, TSource> observer)
-                : base(stream, observer)
+            outputBatch.Count = batch.Count;
+
+            var count = batch.Count;
+
+            var srckey = batch.key.col;
+            var destkey = outputBatch.key.col;
+            var destpayload = outputBatch;
+            fixed (long* srcbv = batch.bitvector.col)
             {
-                this.keySelector = stream.KeySelector;
-                this.keySelectorFunc = this.keySelector.Compile();
-                this.keyComparer = stream.Properties.KeyEqualityComparer.GetGetHashCodeExpr();
-                this.innerHashCode = this.keyComparer.Compile();
-
-                this.errorMessages = stream.ErrorMessages;
-                this.l1Pool = MemoryManager.GetMemoryPool<TInnerKey, TSource>(stream.Properties.IsColumnar);
-            }
-
-            public unsafe void OnNext(StreamMessage<TOuterKey, TSource> batch)
-            {
-                this.l1Pool.Get(out StreamMessage<TInnerKey, TSource> outputBatch);
-                outputBatch.vsync = batch.vsync;
-                outputBatch.vother = batch.vother;
-                outputBatch.payload = batch.payload;
-                outputBatch.hash = batch.hash.MakeWritable(this.l1Pool.intPool);
-                outputBatch.bitvector = batch.bitvector;
-                this.l1Pool.GetKey(out outputBatch.key);
-
-                outputBatch.Count = batch.Count;
-
-                var count = batch.Count;
-
-                var destkey = outputBatch.key.col;
-                var destpayload = outputBatch;
-                fixed (long* srcbv = batch.bitvector.col)
+                fixed (int* desthash = outputBatch.hash.col)
                 {
-                    fixed (int* desthash = outputBatch.hash.col)
+                    for (int i = 0; i < count; i++)
                     {
-                        for (int i = 0; i < count; i++)
-                        {
-                            if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0) continue;
-                            var key = this.keySelectorFunc(destpayload[i]);
-                            destkey[i] = key;
-                            desthash[i] = this.innerHashCode(key);
-                        }
+                        if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0) continue;
+                        var key = this.keySelectorFunc(destpayload[i]);
+                        var innerHash = this.innerHashCode(key);
+                        var hash = desthash[i] ^ innerHash;
+
+                        destkey[i].outerGroup = srckey[i];
+                        destkey[i].innerGroup = key;
+                        destkey[i].hashCode = hash;
+                        desthash[i] = hash;
                     }
                 }
-
-                batch.key.Return();
-                batch.Return();
-                this.Observer.OnNext(outputBatch);
             }
 
-            public override void ProduceQueryPlan(PlanNode previous)
-            {
-                this.Observer.ProduceQueryPlan(new GroupPlanNode(
-                    previous,
-                    this,
-                    typeof(TOuterKey),
-                    typeof(TInnerKey),
-                    typeof(TSource),
-                    this.keySelector,
-                    int.MinValue,
-                    1,
-                    false,
-                    false,
-                    this.errorMessages));
-            }
-
-            public override int CurrentlyBufferedOutputCount => 0;
-
-            public override int CurrentlyBufferedInputCount => 0;
+            batch.key.Return();
+            batch.Return();
+            this.Observer.OnNext(outputBatch);
         }
+
+        public override void ProduceQueryPlan(PlanNode previous)
+        {
+            this.Observer.ProduceQueryPlan(new GroupPlanNode(
+                previous,
+                this,
+                typeof(TOuterKey),
+                typeof(CompoundGroupKey<TOuterKey, TInnerKey>),
+                typeof(TSource),
+                this.keySelector,
+                int.MinValue,
+                1,
+                false,
+                false,
+                this.errorMessages));
+        }
+
+        public override int CurrentlyBufferedOutputCount => 0;
+
+        public override int CurrentlyBufferedInputCount => 0;
+    }
+
+    [DataContract]
+    internal sealed class GroupPipe<TOuterKey, TSource, TInnerKey> :
+        Pipe<TInnerKey, TSource>, IStreamObserver<TOuterKey, TSource>
+    {
+        [SchemaSerialization]
+        private readonly Expression<Func<TSource, TInnerKey>> keySelector;
+        private readonly Func<TSource, TInnerKey> keySelectorFunc;
+        [SchemaSerialization]
+        private readonly Expression<Func<TInnerKey, int>> keyComparer;
+        private readonly Func<TInnerKey, int> innerHashCode;
+
+        private readonly MemoryPool<TInnerKey, TSource> l1Pool;
+        private readonly string errorMessages;
+
+        [Obsolete("Used only by serialization. Do not call directly.")]
+        public GroupPipe() { }
+
+        public GroupPipe(
+            GroupStreamable<TOuterKey, TSource, TInnerKey> stream,
+            IStreamObserver<TInnerKey, TSource> observer)
+            : base(stream, observer)
+        {
+            this.keySelector = stream.KeySelector;
+            this.keySelectorFunc = this.keySelector.Compile();
+            this.keyComparer = stream.Properties.KeyEqualityComparer.GetGetHashCodeExpr();
+            this.innerHashCode = this.keyComparer.Compile();
+
+            this.errorMessages = stream.ErrorMessages;
+            this.l1Pool = MemoryManager.GetMemoryPool<TInnerKey, TSource>(stream.Properties.IsColumnar);
+        }
+
+        public unsafe void OnNext(StreamMessage<TOuterKey, TSource> batch)
+        {
+            this.l1Pool.Get(out StreamMessage<TInnerKey, TSource> outputBatch);
+            outputBatch.vsync = batch.vsync;
+            outputBatch.vother = batch.vother;
+            outputBatch.payload = batch.payload;
+            outputBatch.hash = batch.hash.MakeWritable(this.l1Pool.intPool);
+            outputBatch.bitvector = batch.bitvector;
+            this.l1Pool.GetKey(out outputBatch.key);
+
+            outputBatch.Count = batch.Count;
+
+            var count = batch.Count;
+
+            var destkey = outputBatch.key.col;
+            var destpayload = outputBatch;
+            fixed (long* srcbv = batch.bitvector.col)
+            {
+                fixed (int* desthash = outputBatch.hash.col)
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0) continue;
+                        var key = this.keySelectorFunc(destpayload[i]);
+                        destkey[i] = key;
+                        desthash[i] = this.innerHashCode(key);
+                    }
+                }
+            }
+
+            batch.key.Return();
+            batch.Return();
+            this.Observer.OnNext(outputBatch);
+        }
+
+        public override void ProduceQueryPlan(PlanNode previous)
+        {
+            this.Observer.ProduceQueryPlan(new GroupPlanNode(
+                previous,
+                this,
+                typeof(TOuterKey),
+                typeof(TInnerKey),
+                typeof(TSource),
+                this.keySelector,
+                int.MinValue,
+                1,
+                false,
+                false,
+                this.errorMessages));
+        }
+
+        public override int CurrentlyBufferedOutputCount => 0;
+
+        public override int CurrentlyBufferedInputCount => 0;
+    }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Group/GroupPipe.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Group/GroupPipe.tt
@@ -24,126 +24,126 @@ namespace Microsoft.StreamProcessing
 <#  var groupDomain = i == 0 ? new [] { 0, 1 } : new [] { 1 };
     foreach (var j in groupDomain) { #>
 
-        [DataContract]
-        internal sealed class <#= j == 0 ? "Partitioned" : string.Empty #>Group<#= nestedInfix #>Pipe<TOuterKey, TSource, TInnerKey> :
-            Pipe<<#= innerKey #>, TSource>, IStreamObserver<TOuterKey, TSource>
+    [DataContract]
+    internal sealed class <#= j == 0 ? "Partitioned" : string.Empty #>Group<#= nestedInfix #>Pipe<TOuterKey, TSource, TInnerKey> :
+        Pipe<<#= innerKey #>, TSource>, IStreamObserver<TOuterKey, TSource>
+    {
+        [SchemaSerialization]
+        private readonly Expression<Func<TSource, TInnerKey>> keySelector;
+        private readonly Func<TSource, TInnerKey> keySelectorFunc;
+        [SchemaSerialization]
+        private readonly Expression<Func<TInnerKey, int>> keyComparer;
+        private readonly Func<TInnerKey, int> innerHashCode;
+
+        private readonly MemoryPool<<#= innerKey #>, TSource> l1Pool;
+        private readonly string errorMessages;
+
+        [Obsolete("Used only by serialization. Do not call directly.")]
+        public <#= j == 0 ? "Partitioned" : string.Empty #>Group<#= nestedInfix #>Pipe() { }
+
+        public <#= j == 0 ? "Partitioned" : string.Empty #>Group<#= nestedInfix #>Pipe(
+            Group<#= nestedInfix #>Streamable<TOuterKey, TSource, TInnerKey> stream,
+            IStreamObserver<<#= innerKey #>, TSource> observer)
+            : base(stream, observer)
         {
-            [SchemaSerialization]
-            private readonly Expression<Func<TSource, TInnerKey>> keySelector;
-            private readonly Func<TSource, TInnerKey> keySelectorFunc;
-            [SchemaSerialization]
-            private readonly Expression<Func<TInnerKey, int>> keyComparer;
-            private readonly Func<TInnerKey, int> innerHashCode;
-
-            private readonly MemoryPool<<#= innerKey #>, TSource> l1Pool;
-            private readonly string errorMessages;
-
-            [Obsolete("Used only by serialization. Do not call directly.")]
-            public <#= j == 0 ? "Partitioned" : string.Empty #>Group<#= nestedInfix #>Pipe() { }
-
-            public <#= j == 0 ? "Partitioned" : string.Empty #>Group<#= nestedInfix #>Pipe(
-                Group<#= nestedInfix #>Streamable<TOuterKey, TSource, TInnerKey> stream,
-                IStreamObserver<<#= innerKey #>, TSource> observer)
-                : base(stream, observer)
-            {
-                this.keySelector = stream.KeySelector;
-                this.keySelectorFunc = this.keySelector.Compile();
+            this.keySelector = stream.KeySelector;
+            this.keySelectorFunc = this.keySelector.Compile();
 <# if (i == 0) { #>
-                this.keyComparer = ((CompoundGroupKeyEqualityComparer<TOuterKey, TInnerKey>)stream.Properties.KeyEqualityComparer).innerComparer.GetGetHashCodeExpr();
+            this.keyComparer = ((CompoundGroupKeyEqualityComparer<TOuterKey, TInnerKey>)stream.Properties.KeyEqualityComparer).innerComparer.GetGetHashCodeExpr();
 <# }
 else { #>
-                this.keyComparer = stream.Properties.KeyEqualityComparer.GetGetHashCodeExpr();
+            this.keyComparer = stream.Properties.KeyEqualityComparer.GetGetHashCodeExpr();
 <# } #>
-                this.innerHashCode = this.keyComparer.Compile();
+            this.innerHashCode = this.keyComparer.Compile();
 
-                this.errorMessages = stream.ErrorMessages;
-                this.l1Pool = MemoryManager.GetMemoryPool<<#= innerKey #>, TSource>(stream.Properties.IsColumnar);
-            }
+            this.errorMessages = stream.ErrorMessages;
+            this.l1Pool = MemoryManager.GetMemoryPool<<#= innerKey #>, TSource>(stream.Properties.IsColumnar);
+        }
 
-            public unsafe void OnNext(StreamMessage<TOuterKey, TSource> batch)
-            {
-                this.l1Pool.Get(out StreamMessage<<#= innerKey #>, TSource> outputBatch);
-                outputBatch.vsync = batch.vsync;
-                outputBatch.vother = batch.vother;
-                outputBatch.payload = batch.payload;
-                outputBatch.hash = batch.hash.MakeWritable(this.l1Pool.intPool);
-                outputBatch.bitvector = batch.bitvector;
-                this.l1Pool.GetKey(out outputBatch.key);
+        public unsafe void OnNext(StreamMessage<TOuterKey, TSource> batch)
+        {
+            this.l1Pool.Get(out StreamMessage<<#= innerKey #>, TSource> outputBatch);
+            outputBatch.vsync = batch.vsync;
+            outputBatch.vother = batch.vother;
+            outputBatch.payload = batch.payload;
+            outputBatch.hash = batch.hash.MakeWritable(this.l1Pool.intPool);
+            outputBatch.bitvector = batch.bitvector;
+            this.l1Pool.GetKey(out outputBatch.key);
 
-                outputBatch.Count = batch.Count;
+            outputBatch.Count = batch.Count;
 
-                var count = batch.Count;
+            var count = batch.Count;
 
 <# if (i == 0) { #>
-                var srckey = batch.key.col;
+            var srckey = batch.key.col;
 <# } #>
-                var destkey = outputBatch.key.col;
-                var destpayload = outputBatch;
-                fixed (long* srcbv = batch.bitvector.col)
+            var destkey = outputBatch.key.col;
+            var destpayload = outputBatch;
+            fixed (long* srcbv = batch.bitvector.col)
+            {
+                fixed (int* desthash = outputBatch.hash.col)
                 {
-                    fixed (int* desthash = outputBatch.hash.col)
+                    for (int i = 0; i < count; i++)
                     {
-                        for (int i = 0; i < count; i++)
-                        {
 <# if (j == 0) { #>
-                            if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0)
+                        if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0)
+                        {
+                            if (batch.vother.col[i] == long.MinValue)
                             {
-                                if (batch.vother.col[i] == long.MinValue)
-                                {
-                                    destkey[i].outerGroup = srckey[i];
-                                    destkey[i].innerGroup = default;
-                                    desthash[i] = batch.hash.col[i];
-                                    outputBatch.bitvector.col[i >> 6] |= (1L << (i & 0x3f));
-                                }
-                                continue;
+                                destkey[i].outerGroup = srckey[i];
+                                destkey[i].innerGroup = default;
+                                desthash[i] = batch.hash.col[i];
+                                outputBatch.bitvector.col[i >> 6] |= (1L << (i & 0x3f));
                             }
-<# }
-else { #>
-                            if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0) continue;
-<# } #>
-                            var key = this.keySelectorFunc(destpayload[i]);
-<# if (i == 0) { #>
-                            var innerHash = this.innerHashCode(key);
-                            var hash = desthash[i] ^ innerHash;
-
-                            destkey[i].outerGroup = srckey[i];
-                            destkey[i].innerGroup = key;
-                            destkey[i].hashCode = hash;
-                            desthash[i] = hash;
-<# }
-else { #>
-                            destkey[i] = key;
-                            desthash[i] = this.innerHashCode(key);
-<# } #>
+                            continue;
                         }
+<# }
+else { #>
+                        if ((srcbv[i >> 6] & (1L << (i & 0x3f))) != 0) continue;
+<# } #>
+                        var key = this.keySelectorFunc(destpayload[i]);
+<# if (i == 0) { #>
+                        var innerHash = this.innerHashCode(key);
+                        var hash = desthash[i] ^ innerHash;
+
+                        destkey[i].outerGroup = srckey[i];
+                        destkey[i].innerGroup = key;
+                        destkey[i].hashCode = hash;
+                        desthash[i] = hash;
+<# }
+else { #>
+                        destkey[i] = key;
+                        desthash[i] = this.innerHashCode(key);
+<# } #>
                     }
                 }
-
-                batch.key.Return();
-                batch.Return();
-                this.Observer.OnNext(outputBatch);
             }
 
-            public override void ProduceQueryPlan(PlanNode previous)
-            {
-                this.Observer.ProduceQueryPlan(new GroupPlanNode(
-                    previous,
-                    this,
-                    typeof(TOuterKey),
-                    typeof(<#= innerKey #>),
-                    typeof(TSource),
-                    this.keySelector,
-                    int.MinValue,
-                    1,
-                    false,
-                    false,
-                    this.errorMessages));
-            }
-
-            public override int CurrentlyBufferedOutputCount => 0;
-
-            public override int CurrentlyBufferedInputCount => 0;
+            batch.key.Return();
+            batch.Return();
+            this.Observer.OnNext(outputBatch);
         }
+
+        public override void ProduceQueryPlan(PlanNode previous)
+        {
+            this.Observer.ProduceQueryPlan(new GroupPlanNode(
+                previous,
+                this,
+                typeof(TOuterKey),
+                typeof(<#= innerKey #>),
+                typeof(TSource),
+                this.keySelector,
+                int.MinValue,
+                1,
+                false,
+                false,
+                this.errorMessages));
+        }
+
+        public override int CurrentlyBufferedOutputCount => 0;
+
+        public override int CurrentlyBufferedInputCount => 0;
+    }
 <# } #>
 <# } #>
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/GroupedWindow/GroupedWindowPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/GroupedWindow/GroupedWindowPipe.cs
@@ -126,8 +126,8 @@ namespace Microsoft.StreamProcessing
                             int c = this.batch.Count;
                             this.batch.vsync.col[c] = col_vsync[i];
                             this.batch.vother.col[c] = long.MinValue;
-                            this.batch.key.col[c] = batch.key.col[i];
-                            this.batch.hash.col[c] = batch.key.col[i].GetHashCode();
+                            this.batch.key.col[c] = Empty.Default;
+                            this.batch.hash.col[c] = 0;
                             this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
@@ -360,12 +360,10 @@ namespace Microsoft.StreamProcessing
         public override int CurrentlyBufferedInputCount => this.aggregateByKey.Count;
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new GroupedWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new GroupedWindowPlanNode<TInput, TState, TOutput>(
                 previous, this,
                 typeof(TKey), typeof(TInput), typeof(TOutput), this.aggregate, this.keySelectorExpr, this.finalResultSelectorExpr,
                 false, this.errorMessages, false));
-        }
 
         protected override void UpdatePointers()
         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/GroupedWindow/GroupedWindowPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/GroupedWindow/GroupedWindowPipe.cs
@@ -82,9 +82,9 @@ namespace Microsoft.StreamProcessing
 
             var comparer = EqualityComparerExpression<TKey>.Default;
             this.keyComparerEqualsExpr = comparer.GetEqualsExpr();
-            this.keyComparerEquals = this.keyComparerEqualsExpr.Compile();
+            this.keyComparerEquals = EqualityComparerExpression<TKey>.DefaultEqualsFunction;
             this.keyComparerGetHashCodeExpr = comparer.GetGetHashCodeExpr();
-            this.keyComparerGetHashCode = this.keyComparerGetHashCodeExpr.Compile();
+            this.keyComparerGetHashCode = EqualityComparerExpression<TKey>.DefaultGetHashCodeFunction;
 
             this.keySelectorExpr = stream.KeySelector;
             this.keySelector = this.keySelectorExpr.Compile();

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/GroupedWindow/GroupedWindowTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/GroupedWindow/GroupedWindowTemplate.cs
@@ -367,7 +367,7 @@ using Microsoft.StreamProcessing.Aggregates;
                         this.batch.vother.col[c] = long.MinValue;
                         this.batch.key.col[c] = default;
                         this.batch[c] = default;
-                        this.batch.hash.col[c] = batch.key.col[i].GetHashCode();
+                        this.batch.hash.col[c] = 0;
                         this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/GroupedWindow/GroupedWindowTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/GroupedWindow/GroupedWindowTemplate.tt
@@ -198,7 +198,7 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<Micro
                         this.batch.vother.col[c] = long.MinValue;
                         this.batch.key.col[c] = default;
                         this.batch[c] = default;
-                        this.batch.hash.col[c] = batch.key.col[i].GetHashCode();
+                        this.batch.hash.col[c] = 0;
                         this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/LeftAntiSemiJoin/PartitionedLeftAntiSemiJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/LeftAntiSemiJoin/PartitionedLeftAntiSemiJoinPipe.cs
@@ -225,8 +225,8 @@ namespace Microsoft.StreamProcessing
                 while (true)
                 {
                     var old = partition.currTime;
-                    bool hasLeftBatch = leftWorking.TryPeekFirst(out LEntry leftEntry);
-                    bool hasRightBatch = rightWorking.TryPeekFirst(out REntry rightEntry);
+                    bool hasLeftBatch = leftWorking.TryPeekFirst(out var leftEntry);
+                    bool hasRightBatch = rightWorking.TryPeekFirst(out var rightEntry);
                     if (hasLeftBatch && hasRightBatch)
                     {
                         partition.nextLeftTime = leftEntry.Sync;
@@ -922,9 +922,7 @@ namespace Microsoft.StreamProcessing
             }
 
             public override string ToString()
-            {
-                return "[Start=" + this.Start + ", CurrentStart=" + this.CurrentStart + ", End=" + this.End + ", Key='" + this.Key + "', Payload='" + this.Payload + "']";
-            }
+                => "[Start=" + this.Start + ", CurrentStart=" + this.CurrentStart + ", End=" + this.End + ", Key='" + this.Key + "', Payload='" + this.Payload + "']";
         }
 
         [DataContract]
@@ -943,9 +941,7 @@ namespace Microsoft.StreamProcessing
             }
 
             public override string ToString()
-            {
-                return "[Key='" + this.Key + "', Count=" + this.Count + "]";
-            }
+                => "[Key='" + this.Key + "', Count=" + this.Count + "]";
         }
 
         [DataContract]
@@ -964,9 +960,7 @@ namespace Microsoft.StreamProcessing
             }
 
             public override string ToString()
-            {
-                return "[Key='" + this.Key + "', Hash=" + this.Hash + "]";
-            }
+                => "[Key='" + this.Key + "', Hash=" + this.Hash + "]";
         }
 
         public override bool LeftInputHasState

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Partition/PartitionPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Partition/PartitionPipe.cs
@@ -20,6 +20,7 @@ namespace Microsoft.StreamProcessing
         [SchemaSerialization]
         private readonly long partitionLag;
 
+        private readonly Func<TPartitionKey, int> keyComparerGetHashCode;
         private readonly MemoryPool<PartitionKey<TPartitionKey>, TPayload> l1Pool;
 
         [Obsolete("Used only by serialization. Do not call directly.")]
@@ -30,6 +31,8 @@ namespace Microsoft.StreamProcessing
             IStreamObserver<PartitionKey<TPartitionKey>, TPayload> observer)
             : base(stream, observer)
         {
+            var keyComparerGetHashCodeExpr = EqualityComparerExpression<TPartitionKey>.Default.GetGetHashCodeExpr();
+            this.keyComparerGetHashCode = keyComparerGetHashCodeExpr.Compile();
             this.keySelector = stream.KeySelector;
             this.keySelectorFunc = this.keySelector.Compile();
             this.partitionLag = stream.PartitionLag;
@@ -39,14 +42,9 @@ namespace Microsoft.StreamProcessing
         public unsafe void OnNext(StreamMessage<Empty, TPayload> batch)
         {
             this.l1Pool.Get(out StreamMessage<PartitionKey<TPartitionKey>, TPayload> outputBatch);
-            if (this.partitionLag > 0)
-            {
-                outputBatch.vsync = batch.vsync.MakeWritable(this.l1Pool.longPool);
-            }
-            else
-            {
-                outputBatch.vsync = batch.vsync;
-            }
+            outputBatch.vsync = this.partitionLag > 0
+                ? batch.vsync.MakeWritable(this.l1Pool.longPool)
+                : batch.vsync;
             outputBatch.vother = batch.vother.MakeWritable(this.l1Pool.longPool);
             outputBatch.payload = batch.payload;
             outputBatch.hash = batch.hash.MakeWritable(this.l1Pool.intPool);
@@ -76,7 +74,7 @@ namespace Microsoft.StreamProcessing
 
                     var key = this.keySelectorFunc(destPayload[i]);
                     destKey[i] = new PartitionKey<TPartitionKey> { Key = key };
-                    destHash[i] = key.GetHashCode();
+                    destHash[i] = this.keyComparerGetHashCode(key);
                 }
             }
 
@@ -86,13 +84,11 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new PartitionPlanNode(
+            => this.Observer.ProduceQueryPlan(new PartitionPlanNode(
                 previous,
                 this,
                 typeof(PartitionKey<TPartitionKey>),
                 typeof(TPayload), this.keySelector, this.partitionLag));
-        }
 
         public override int CurrentlyBufferedOutputCount => 0;
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Partition/PartitionPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Partition/PartitionPipe.cs
@@ -31,8 +31,7 @@ namespace Microsoft.StreamProcessing
             IStreamObserver<PartitionKey<TPartitionKey>, TPayload> observer)
             : base(stream, observer)
         {
-            var keyComparerGetHashCodeExpr = EqualityComparerExpression<TPartitionKey>.Default.GetGetHashCodeExpr();
-            this.keyComparerGetHashCode = keyComparerGetHashCodeExpr.Compile();
+            this.keyComparerGetHashCode = EqualityComparerExpression<TPartitionKey>.DefaultGetHashCodeFunction;
             this.keySelector = stream.KeySelector;
             this.keySelectorFunc = this.keySelector.Compile();
             this.partitionLag = stream.PartitionLag;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Select/SelectPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Select/SelectPipe.cs
@@ -33,12 +33,10 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SelectPlanNode(
+            => this.Observer.ProduceQueryPlan(new SelectPlanNode(
                 previous, this,
                 typeof(TKey), typeof(TPayload), typeof(TResult),
                 this.selector, false, false, false, this.errorMessages));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TPayload> batch)
         {
@@ -96,12 +94,10 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SelectPlanNode(
+            => this.Observer.ProduceQueryPlan(new SelectPlanNode(
                 previous, this,
                 typeof(TKey), typeof(TPayload), typeof(TResult),
                 this.selector, false, true, false, this.errorMessages));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TPayload> batch)
         {
@@ -161,12 +157,10 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SelectPlanNode(
+            => this.Observer.ProduceQueryPlan(new SelectPlanNode(
                 previous, this,
                 typeof(TKey), typeof(TPayload), typeof(TResult),
                 this.selector, true, false, false, this.errorMessages));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TPayload> batch)
         {
@@ -225,12 +219,10 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SelectPlanNode(
+            => this.Observer.ProduceQueryPlan(new SelectPlanNode(
                 previous, this,
                 typeof(TKey), typeof(TPayload), typeof(TResult),
                 this.selector, true, true, false, this.errorMessages));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TPayload> batch)
         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Select/SelectPipe.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Select/SelectPipe.tt
@@ -46,12 +46,10 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SelectPlanNode(
+            => this.Observer.ProduceQueryPlan(new SelectPlanNode(
                 previous, this,
                 typeof(TKey), typeof(TPayload), typeof(TResult),
                 this.selector, <#= hasKey.ToString().ToLowerInvariant() #>, <#= hasStartEdge.ToString().ToLowerInvariant() #>, false, this.errorMessages));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TPayload> batch)
         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Shuffle/ShufflePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Shuffle/ShufflePipe.cs
@@ -300,8 +300,7 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
+            => this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
                 previous,
                 this,
                 typeof(TOuterKey),
@@ -313,7 +312,6 @@ namespace Microsoft.StreamProcessing
                 true,
                 false,
                 this.errorMessages)));
-        }
 
         public override int CurrentlyBufferedOutputCount => 0;
 
@@ -591,8 +589,7 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
+            => this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
                 previous,
                 this,
                 typeof(TOuterKey),
@@ -604,7 +601,6 @@ namespace Microsoft.StreamProcessing
                 true,
                 false,
                 this.errorMessages)));
-        }
 
         public override int CurrentlyBufferedOutputCount => 0;
 
@@ -877,8 +873,7 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
+            => this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
                 previous,
                 this,
                 typeof(TOuterKey),
@@ -890,7 +885,6 @@ namespace Microsoft.StreamProcessing
                 true,
                 false,
                 this.errorMessages)));
-        }
 
         public override int CurrentlyBufferedOutputCount => 0;
 
@@ -1150,8 +1144,7 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
+            => this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
                 previous,
                 this,
                 typeof(TOuterKey),
@@ -1163,7 +1156,6 @@ namespace Microsoft.StreamProcessing
                 true,
                 false,
                 this.errorMessages)));
-        }
 
         public override int CurrentlyBufferedOutputCount => 0;
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Shuffle/ShufflePipe.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Shuffle/ShufflePipe.tt
@@ -299,8 +299,7 @@ for (int i = 0; i < 3; i++)
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
+            => this.Observers.ForEach(o => o.ProduceQueryPlan(new GroupPlanNode(
                 previous,
                 this,
                 typeof(TOuterKey),
@@ -312,7 +311,6 @@ for (int i = 0; i < 3; i++)
                 true,
                 false,
                 this.errorMessages)));
-        }
 
         public override int CurrentlyBufferedOutputCount => 0;
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/PartitionedSnapshotWindowHoppingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/PartitionedSnapshotWindowHoppingPipe.cs
@@ -98,11 +98,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(TKey), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.Hopping, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TInput> batch)
         {
@@ -147,7 +145,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vsync.col[c] = col_vsync[i];
                         this.batch.vother.col[c] = long.MinValue;
                         this.batch.key.col[c] = colkey[i];
-                        this.batch.hash.col[c] = colkey[i].GetHashCode();
+                        this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
                         this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
@@ -187,7 +185,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = heldState.timestamp;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = colkey[i];
-                            this.batch.hash.col[c] = colkey[i].GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize)
                             {
@@ -323,7 +321,7 @@ namespace Microsoft.StreamProcessing
                     this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                     this.batch.payload.col[c] = this.computeResult(iter1entry.value.state);
                     this.batch.key.col[c] = iter1entry.key;
-                    this.batch.hash.col[c] = iter1entry.key.GetHashCode();
+                    this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                     this.batch.Count++;
                     if (this.batch.Count == Config.DataBatchSize) FlushContents();
                 }
@@ -355,7 +353,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = heldState.timestamp;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = ecqState.states.entries[iter].key;
-                            this.batch.hash.col[c] = ecqState.states.entries[iter].key.GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.states.entries[iter].key);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         }
@@ -377,7 +375,7 @@ namespace Microsoft.StreamProcessing
                                 this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                                 this.batch.payload.col[c] = this.computeResult(heldState.state);
                                 this.batch.key.col[c] = ecqState.states.entries[iter].key;
-                                this.batch.hash.col[c] = ecqState.states.entries[iter].key.GetHashCode();
+                                this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.states.entries[iter].key);
                                 this.batch.Count++;
                                 if (this.batch.Count == Config.DataBatchSize) FlushContents();
                             }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/PartitionedSnapshotWindowHoppingPipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/PartitionedSnapshotWindowHoppingPipeSimple.cs
@@ -75,11 +75,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(PartitionKey<TPartitionKey>), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.Hopping, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<PartitionKey<TPartitionKey>, TInput> batch)
         {
@@ -123,7 +121,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vsync.col[c] = col_vsync[i];
                         this.batch.vother.col[c] = PartitionedStreamEvent.PunctuationOtherTime;
                         this.batch.key.col[c] = colkey[i];
-                        this.batch.hash.col[c] = colkey[i].GetHashCode();
+                        this.batch.hash.col[c] = partitionEntry.currentHash;
                         this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
@@ -160,7 +158,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = entry.currentState.timestamp;
                             this.batch.payload.col[c] = this.computeResult(entry.currentState.state);
                             this.batch.key.col[c] = entry.currentKey;
-                            this.batch.hash.col[c] = entry.currentKey.GetHashCode();
+                            this.batch.hash.col[c] = entry.currentHash;
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize)
                             {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingPipe.cs
@@ -99,11 +99,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(TKey), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.Hopping, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TInput> batch)
         {
@@ -166,7 +164,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = heldState.timestamp;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = colkey[i];
-                            this.batch.hash.col[c] = colkey[i].GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         }
@@ -260,7 +258,7 @@ namespace Microsoft.StreamProcessing
                     this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                     this.batch.payload.col[c] = this.computeResult(iter1entry.value.state);
                     this.batch.key.col[c] = iter1entry.key;
-                    this.batch.hash.col[c] = iter1entry.key.GetHashCode();
+                    this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                     this.batch.Count++;
                     if (this.batch.Count == Config.DataBatchSize) FlushContents();
                 }
@@ -290,7 +288,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vother.col[c] = heldState.timestamp;
                         this.batch.payload.col[c] = this.computeResult(heldState.state);
                         this.batch.key.col[c] = ecqState.states.entries[iter].key;
-                        this.batch.hash.col[c] = ecqState.states.entries[iter].key.GetHashCode();
+                        this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.states.entries[iter].key);
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
                     }
@@ -312,7 +310,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = ecqState.states.entries[iter].key;
-                            this.batch.hash.col[c] = ecqState.states.entries[iter].key.GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.states.entries[iter].key);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingPipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingPipeSimple.cs
@@ -83,11 +83,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(Empty), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.Hopping, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<Empty, TInput> batch)
         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/PartitionedSnapshotWindowPriorityQueuePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/PartitionedSnapshotWindowPriorityQueuePipe.cs
@@ -97,11 +97,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(TKey), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.PriorityQueue, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TInput> batch)
         {
@@ -146,7 +144,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vsync.col[c] = col_vsync[i];
                         this.batch.vother.col[c] = long.MinValue;
                         this.batch.key.col[c] = colkey[i];
-                        this.batch.hash.col[c] = colkey[i].GetHashCode();
+                        this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
                         this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
@@ -186,7 +184,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = heldState.timestamp;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = colkey[i];
-                            this.batch.hash.col[c] = colkey[i].GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         }
@@ -304,7 +302,7 @@ namespace Microsoft.StreamProcessing
                     this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                     this.batch.payload.col[c] = this.computeResult(iter1entry.value.state);
                     this.batch.key.col[c] = iter1entry.key;
-                    this.batch.hash.col[c] = iter1entry.key.GetHashCode();
+                    this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                     this.batch.Count++;
                     if (this.batch.Count == Config.DataBatchSize) FlushContents();
                 }
@@ -334,7 +332,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vother.col[c] = heldState.timestamp;
                         this.batch.payload.col[c] = this.computeResult(heldState.state);
                         this.batch.key.col[c] = ecqState.entries[iter].key;
-                        this.batch.hash.col[c] = ecqState.entries[iter].key.GetHashCode();
+                        this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.entries[iter].key);
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
                     }
@@ -356,7 +354,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = ecqState.entries[iter].key;
-                            this.batch.hash.col[c] = ecqState.entries[iter].key.GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.entries[iter].key);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/PartitionedSnapshotWindowPriorityQueuePipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/PartitionedSnapshotWindowPriorityQueuePipeSimple.cs
@@ -73,11 +73,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(PartitionKey<TPartitionKey>), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.PriorityQueue, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<PartitionKey<TPartitionKey>, TInput> batch)
         {
@@ -122,7 +120,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vsync.col[c] = col_vsync[i];
                         this.batch.vother.col[c] = long.MinValue;
                         this.batch.key.col[c] = colkey[i];
-                        this.batch.hash.col[c] = colkey[i].GetHashCode();
+                        this.batch.hash.col[c] = partitionEntry.currentHash;
                         this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
@@ -157,7 +155,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = entry.currentState.timestamp;
                             this.batch.payload.col[c] = this.computeResult(entry.currentState.state);
                             this.batch.key.col[c] = entry.currentKey;
-                            this.batch.hash.col[c] = entry.currentKey.GetHashCode();
+                            this.batch.hash.col[c] = entry.currentHash;
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize)
                             {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueuePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueuePipe.cs
@@ -97,11 +97,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(TKey), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.PriorityQueue, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TInput> batch)
         {
@@ -164,7 +162,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = heldState.timestamp;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = colkey[i];
-                            this.batch.hash.col[c] = colkey[i].GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize)
                             {
@@ -254,7 +252,7 @@ namespace Microsoft.StreamProcessing
                     this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                     this.batch.payload.col[c] = this.computeResult(iter1entry.value.state);
                     this.batch.key.col[c] = iter1entry.key;
-                    this.batch.hash.col[c] = iter1entry.key.GetHashCode();
+                    this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                     this.batch.Count++;
                     if (this.batch.Count == Config.DataBatchSize) FlushContents();
                 }
@@ -284,7 +282,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vother.col[c] = heldState.timestamp;
                         this.batch.payload.col[c] = this.computeResult(heldState.state);
                         this.batch.key.col[c] = ecqState.entries[iter].key;
-                        this.batch.hash.col[c] = ecqState.entries[iter].key.GetHashCode();
+                        this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.entries[iter].key);
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
                     }
@@ -306,7 +304,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = ecqState.entries[iter].key;
-                            this.batch.hash.col[c] = ecqState.entries[iter].key.GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.entries[iter].key);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueuePipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueuePipeSimple.cs
@@ -79,11 +79,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(Empty), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.PriorityQueue, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<Empty, TInput> batch)
         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/PartitionedSnapshotWindowSlidingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/PartitionedSnapshotWindowSlidingPipe.cs
@@ -96,11 +96,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(TKey), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.Sliding, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TInput> batch)
         {
@@ -146,7 +144,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vsync.col[c] = col_vsync[i];
                             this.batch.vother.col[c] = long.MinValue;
                             this.batch.key.col[c] = colkey[i];
-                            this.batch.hash.col[c] = colkey[i].GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
                             this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
@@ -186,7 +184,7 @@ namespace Microsoft.StreamProcessing
                                 this.batch.vother.col[c] = heldState.timestamp;
                                 this.batch.payload.col[c] = this.computeResult(heldState.state);
                                 this.batch.key.col[c] = colkey[i];
-                                this.batch.hash.col[c] = colkey[i].GetHashCode();
+                                this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
                                 this.batch.Count++;
                                 if (this.batch.Count == Config.DataBatchSize)
                                 {
@@ -323,7 +321,7 @@ namespace Microsoft.StreamProcessing
                     this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                     this.batch.payload.col[c] = this.computeResult(iter1entry.value.state);
                     this.batch.key.col[c] = iter1entry.key;
-                    this.batch.hash.col[c] = iter1entry.key.GetHashCode();
+                    this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                     this.batch.Count++;
                     if (this.batch.Count == Config.DataBatchSize) FlushContents();
                 }
@@ -355,7 +353,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = heldState.timestamp;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = ecqState.states.entries[iter].key;
-                            this.batch.hash.col[c] = ecqState.states.entries[iter].key.GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.states.entries[iter].key);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         }
@@ -377,7 +375,7 @@ namespace Microsoft.StreamProcessing
                                 this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                                 this.batch.payload.col[c] = this.computeResult(heldState.state);
                                 this.batch.key.col[c] = ecqState.states.entries[iter].key;
-                                this.batch.hash.col[c] = ecqState.states.entries[iter].key.GetHashCode();
+                                this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.states.entries[iter].key);
                                 this.batch.Count++;
                                 if (this.batch.Count == Config.DataBatchSize) FlushContents();
                             }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/PartitionedSnapshotWindowSlidingPipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/PartitionedSnapshotWindowSlidingPipeSimple.cs
@@ -73,11 +73,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(PartitionKey<TPartitionKey>), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.Sliding, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<PartitionKey<TPartitionKey>, TInput> batch)
         {
@@ -123,7 +121,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vsync.col[c] = col_vsync[i];
                             this.batch.vother.col[c] = long.MinValue;
                             this.batch.key.col[c] = colkey[i];
-                            this.batch.hash.col[c] = colkey[i].GetHashCode();
+                            this.batch.hash.col[c] = partitionEntry.currentHash;
                             this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
@@ -160,7 +158,7 @@ namespace Microsoft.StreamProcessing
                                 this.batch.vother.col[c] = entry.currentState.timestamp;
                                 this.batch.payload.col[c] = this.computeResult(entry.currentState.state);
                                 this.batch.key.col[c] = entry.currentKey;
-                                this.batch.hash.col[c] = entry.currentKey.GetHashCode();
+                                this.batch.hash.col[c] = entry.currentHash;
                                 this.batch.Count++;
                                 if (this.batch.Count == Config.DataBatchSize)
                                 {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingPipe.cs
@@ -98,11 +98,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(TKey), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.Sliding, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TInput> batch)
         {
@@ -166,7 +164,7 @@ namespace Microsoft.StreamProcessing
                                 this.batch.vother.col[c] = heldState.timestamp;
                                 this.batch.payload.col[c] = this.computeResult(heldState.state);
                                 this.batch.key.col[c] = colkey[i];
-                                this.batch.hash.col[c] = colkey[i].GetHashCode();
+                                this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
                                 this.batch.Count++;
                                 if (this.batch.Count == Config.DataBatchSize) FlushContents();
                             }
@@ -261,7 +259,7 @@ namespace Microsoft.StreamProcessing
                     this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                     this.batch.payload.col[c] = this.computeResult(iter1entry.value.state);
                     this.batch.key.col[c] = iter1entry.key;
-                    this.batch.hash.col[c] = iter1entry.key.GetHashCode();
+                    this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                     this.batch.Count++;
                     if (this.batch.Count == Config.DataBatchSize) FlushContents();
                 }
@@ -291,7 +289,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vother.col[c] = heldState.timestamp;
                         this.batch.payload.col[c] = this.computeResult(heldState.state);
                         this.batch.key.col[c] = ecqState.states.entries[iter].key;
-                        this.batch.hash.col[c] = ecqState.states.entries[iter].key.GetHashCode();
+                        this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.states.entries[iter].key);
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
                     }
@@ -313,7 +311,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                             this.batch.payload.col[c] = this.computeResult(heldState.state);
                             this.batch.key.col[c] = ecqState.states.entries[iter].key;
-                            this.batch.hash.col[c] = ecqState.states.entries[iter].key.GetHashCode();
+                            this.batch.hash.col[c] = this.keyComparerGetHashCode(ecqState.states.entries[iter].key);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingPipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingPipeSimple.cs
@@ -82,11 +82,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(Empty), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.Sliding, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<Empty, TInput> batch)
         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/SnapshotWindowStreamable.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/SnapshotWindowStreamable.cs
@@ -100,11 +100,11 @@ namespace Microsoft.StreamProcessing
 
         private static int GetAggregateFunctionsHashCode(IAggregate<TInput, TState, TOutput> a)
         {
-            int x = a.Accumulate().ExpressionToCSharp().GetHashCode();
-            x = x << 3 ^ a.ComputeResult().ExpressionToCSharp().GetHashCode();
-            x = x << 3 ^ a.Deaccumulate().ExpressionToCSharp().GetHashCode();
-            x = x << 3 ^ a.Difference().ExpressionToCSharp().GetHashCode();
-            x = x << 3 ^ a.InitialState().ExpressionToCSharp().GetHashCode();
+            int x = a.Accumulate().ExpressionToCSharp().StableHash();
+            x = x << 3 ^ a.ComputeResult().ExpressionToCSharp().StableHash();
+            x = x << 3 ^ a.Deaccumulate().ExpressionToCSharp().StableHash();
+            x = x << 3 ^ a.Difference().ExpressionToCSharp().StableHash();
+            x = x << 3 ^ a.InitialState().ExpressionToCSharp().StableHash();
             return x;
         }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/StartEdge/PartitionedSnapshotWindowStartEdgePipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/StartEdge/PartitionedSnapshotWindowStartEdgePipeSimple.cs
@@ -63,11 +63,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(PartitionKey<TPartitionKey>), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.StartEdge, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<PartitionKey<TPartitionKey>, TInput> batch)
         {
@@ -112,7 +110,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vsync.col[c] = col_vsync[i];
                         this.batch.vother.col[c] = long.MinValue;
                         this.batch.key.col[c] = colkey[i];
-                        this.batch.hash.col[c] = colkey[i].GetHashCode();
+                        this.batch.hash.col[c] = partitionEntry.currentHash;
                         this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
@@ -138,7 +136,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vother.col[c] = StreamEvent.InfinitySyncTime;
                         this.batch.payload.col[c] = this.computeResult(cstate.state);
                         this.batch.key.col[c] = entry.currentKey;
-                        this.batch.hash.col[c] = entry.currentKey.GetHashCode();
+                        this.batch.hash.col[c] = entry.currentHash;
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         entry.held = false;
@@ -163,7 +161,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vother.col[c] = entry.currentState.timestamp;
                         this.batch.payload.col[c] = this.computeResult(entry.currentState.state);
                         this.batch.key.col[c] = entry.currentKey;
-                        this.batch.hash.col[c] = entry.currentKey.GetHashCode();
+                        this.batch.hash.col[c] = entry.currentHash;
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/StartEdge/SnapshotWindowStartEdgePipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/StartEdge/SnapshotWindowStartEdgePipeSimple.cs
@@ -66,11 +66,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(Empty), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.StartEdge, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<Empty, TInput> batch)
         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/PartitionedSnapshotWindowTumblingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/PartitionedSnapshotWindowTumblingPipe.cs
@@ -38,6 +38,9 @@ namespace Microsoft.StreamProcessing
         [SchemaSerialization]
         private readonly Expression<Func<TKey, TKey, bool>> keyComparerEqualsExpr;
         private readonly Func<TKey, TKey, bool> keyComparerEquals;
+        [SchemaSerialization]
+        private readonly Expression<Func<TKey, int>> keyHashCodeExpr;
+        private readonly Func<TKey, int> keyHashCode;
 
         [DataMember]
         private StreamMessage<TKey, TOutput> batch;
@@ -68,23 +71,22 @@ namespace Microsoft.StreamProcessing
             var comparer = stream.Properties.KeyEqualityComparer;
             this.keyComparerEqualsExpr = comparer.GetEqualsExpr();
             this.keyComparerEquals = this.keyComparerEqualsExpr.Compile();
+            this.keyHashCodeExpr = comparer.GetGetHashCodeExpr();
+            this.keyHashCode = this.keyHashCodeExpr.Compile();
 
             this.errorMessages = stream.ErrorMessages;
             this.pool = MemoryManager.GetMemoryPool<TKey, TOutput>(false);
             this.pool.Get(out this.batch);
             this.batch.Allocate();
-            var getHashCode = comparer.GetGetHashCodeExpr().Compile();
-            this.dictionaryGenerator = comparer.CreateFastDictionaryGenerator<TKey, TState>(1, this.keyComparerEquals, getHashCode, stream.Properties.QueryContainer);
+            this.dictionaryGenerator = comparer.CreateFastDictionaryGenerator<TKey, TState>(1, this.keyComparerEquals, this.keyHashCode, stream.Properties.QueryContainer);
 
             this.hop = hop;
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(TKey), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.StartEdge, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<TKey, TInput> batch)
         {
@@ -165,7 +167,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vother.col[c] = entry.lastSyncTime + this.hop;
                         this.batch.payload.col[c] = this.computeResult(iter1entry.value);
                         this.batch.key.col[c] = iter1entry.key;
-                        this.batch.hash.col[c] = iter1entry.key.GetHashCode();
+                        this.batch.hash.col[c] = this.keyHashCode(iter1entry.key);
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
 
@@ -225,7 +227,7 @@ namespace Microsoft.StreamProcessing
                     this.batch.vother.col[c] = partitionSyncTime + this.hop;
                     this.batch.payload.col[c] = this.computeResult(iter1entry.value);
                     this.batch.key.col[c] = iter1entry.key;
-                    this.batch.hash.col[c] = iter1entry.key.GetHashCode();
+                    this.batch.hash.col[c] = this.keyHashCode(iter1entry.key);
                     this.batch.Count++;
                     if (this.batch.Count == Config.DataBatchSize) FlushContents();
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/PartitionedSnapshotWindowTumblingPipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/PartitionedSnapshotWindowTumblingPipeSimple.cs
@@ -67,11 +67,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(PartitionKey<TPartitionKey>), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.StartEdge, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<PartitionKey<TPartitionKey>, TInput> batch)
         {
@@ -125,7 +123,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.vother.col[c] = long.MinValue;
                             this.batch.key.col[c] = colkey[i];
                             this.batch.hash.col[c] = col_hash[i];
-                            this.batch.bitvector.col[c >> 6] |= (1L << (c & 0x3f));
+                            this.batch.bitvector.col[c >> 6] |= 1L << (c & 0x3f);
                             this.batch.Count++;
                             if (this.batch.Count == Config.DataBatchSize) FlushContents();
                         }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/SnapshotWindowTumblingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/SnapshotWindowTumblingPipe.cs
@@ -38,8 +38,8 @@ namespace Microsoft.StreamProcessing
         private readonly Expression<Func<TKey, TKey, bool>> keyComparerEqualsExpr;
         private readonly Func<TKey, TKey, bool> keyComparerEquals;
         [SchemaSerialization]
-        private readonly Expression<Func<TKey, int>> keyHashCodeExpr;
-        private readonly Func<TKey, int> keyHashCode;
+        private readonly Expression<Func<TKey, int>> keyComparerGetHashCodeExpr;
+        private readonly Func<TKey, int> keyComparerGetHashCode;
 
         [DataMember]
         private StreamMessage<TKey, TOutput> batch;
@@ -68,14 +68,14 @@ namespace Microsoft.StreamProcessing
             var comparer = stream.Properties.KeyEqualityComparer;
             this.keyComparerEqualsExpr = comparer.GetEqualsExpr();
             this.keyComparerEquals = this.keyComparerEqualsExpr.Compile();
-            this.keyHashCodeExpr = comparer.GetGetHashCodeExpr();
-            this.keyHashCode = this.keyHashCodeExpr.Compile();
+            this.keyComparerGetHashCodeExpr = comparer.GetGetHashCodeExpr();
+            this.keyComparerGetHashCode = this.keyComparerGetHashCodeExpr.Compile();
 
             this.errorMessages = stream.ErrorMessages;
             this.pool = MemoryManager.GetMemoryPool<TKey, TOutput>(false);
             this.pool.Get(out this.batch);
             this.batch.Allocate();
-            this.heldAggregates = comparer.CreateFastDictionaryGenerator<TKey, TState>(1, this.keyComparerEquals, this.keyHashCode, stream.Properties.QueryContainer).Invoke();
+            this.heldAggregates = comparer.CreateFastDictionaryGenerator<TKey, TState>(1, this.keyComparerEquals, this.keyComparerGetHashCode, stream.Properties.QueryContainer).Invoke();
 
             this.hop = hop;
         }
@@ -129,7 +129,7 @@ namespace Microsoft.StreamProcessing
                         this.batch.vother.col[c] = this.lastSyncTime + this.hop;
                         this.batch.payload.col[c] = this.computeResult(iter1entry.value);
                         this.batch.key.col[c] = iter1entry.key;
-                        this.batch.hash.col[c] = this.keyHashCode(iter1entry.key);
+                        this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
                     }
@@ -167,7 +167,7 @@ namespace Microsoft.StreamProcessing
                     this.batch.vother.col[c] = this.lastSyncTime + this.hop;
                     this.batch.payload.col[c] = this.computeResult(iter1entry.value);
                     this.batch.key.col[c] = iter1entry.key;
-                    this.batch.hash.col[c] = this.keyHashCode(iter1entry.key);
+                    this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                     this.batch.Count++;
                     if (this.batch.Count == Config.DataBatchSize) FlushContents();
                 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/SnapshotWindowTumblingPipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/SnapshotWindowTumblingPipeSimple.cs
@@ -69,11 +69,9 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
+            => this.Observer.ProduceQueryPlan(new SnapshotWindowPlanNode<TInput, TState, TOutput>(
                 previous, this, typeof(Empty), typeof(TInput), typeof(TOutput),
                 AggregatePipeType.StartEdge, this.aggregate, false, this.errorMessages, false));
-        }
 
         public override unsafe void OnNext(StreamMessage<Empty, TInput> batch)
         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/SnapshotWindowTumblingTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/SnapshotWindowTumblingTemplate.cs
@@ -171,7 +171,7 @@ using Microsoft.StreamProcessing.Aggregates;
             this.Write(this.ToStringHelper.ToStringWithCulture(TKey));
             this.Write(", int> keyComparerGetHashCode;\r\n\r\n    ");
  if (!this.isUngrouped) { 
-            this.Write("\r\n    [DataMember]\r\n    private FastDictionary3<");
+            this.Write("\r\n    [DataMember]\r\n    private FastDictionary<");
             this.Write(this.ToStringHelper.ToStringWithCulture(TKey));
             this.Write(", HeldState> heldAggregates;\r\n    ");
  } else { 
@@ -230,7 +230,7 @@ using Microsoft.StreamProcessing.Aggregates;
             this.Write(this.ToStringHelper.ToStringWithCulture(getOutputBatch));
             this.Write("\r\n        this.batch.Allocate();\r\n\r\n        ");
  if (!this.isUngrouped) { 
-            this.Write("        var generator = this.keyComparer.CreateFastDictionary3Generator<");
+            this.Write("        var generator = this.keyComparer.CreateFastDictionaryGenerator<");
             this.Write(this.ToStringHelper.ToStringWithCulture(TKey));
             this.Write(", HeldState>(1, this.keyComparerEquals, this.keyComparerGetHashCode, stream.Prope" +
                     "rties.QueryContainer);\r\n        this.heldAggregates = generator.Invoke();\r\n     " +
@@ -365,7 +365,7 @@ using Microsoft.StreamProcessing.Aggregates;
                     "shContents();\r\n                    currentState = null;\r\n                }\r\n    " +
                     "            ");
  } else { 
-            this.Write("\r\n                    int iter1 = FastDictionary3<");
+            this.Write("\r\n                    int iter1 = FastDictionary<");
             this.Write(this.ToStringHelper.ToStringWithCulture(TKey));
             this.Write(@", HeldState>.IteratorStart;
                     while (this.heldAggregates.Iterate(ref iter1))
@@ -379,7 +379,7 @@ using Microsoft.StreamProcessing.Aggregates;
             this.Write(this.ToStringHelper.ToStringWithCulture(assignToOutput(computeResult("iter1entry.value.state.state"))));
             this.Write(@"
                         this.batch.key.col[c] = iter1entry.key;
-                        this.batch.hash.col[c] = iter1entry.hash;
+                        this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
                     }
@@ -420,7 +420,7 @@ using Microsoft.StreamProcessing.Aggregates;
                     currentState.timestamp = syncTime;
                     // No output because initial state is empty
 
-                    this.heldAggregates.Insert(ref index, currentKey, currentState, currentHash);
+                    this.heldAggregates.Insert(ref index, currentKey, currentState);
                 }
                 else
                 {
@@ -478,7 +478,7 @@ using Microsoft.StreamProcessing.Aggregates;
                     "++;\r\n                if (this.batch.Count == Config.DataBatchSize) FlushContents" +
                     "();\r\n                currentState = null;\r\n            }\r\n            ");
  } else { 
-            this.Write("\r\n            int iter1 = FastDictionary3<");
+            this.Write("\r\n            int iter1 = FastDictionary<");
             this.Write(this.ToStringHelper.ToStringWithCulture(TKey));
             this.Write(@", HeldState>.IteratorStart;
             while (this.heldAggregates.Iterate(ref iter1))
@@ -493,7 +493,7 @@ using Microsoft.StreamProcessing.Aggregates;
             this.Write(@"
 
                 this.batch.key.col[c] = iter1entry.key;
-                this.batch.hash.col[c] = iter1entry.hash;
+                this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                 this.batch.Count++;
                 if (this.batch.Count == Config.DataBatchSize) FlushContents();
             }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/SnapshotWindowTumblingTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Tumbling/SnapshotWindowTumblingTemplate.tt
@@ -40,7 +40,7 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
     <# if (!this.isUngrouped) { #>
 
     [DataMember]
-    private FastDictionary3<<#= TKey #>, HeldState> heldAggregates;
+    private FastDictionary<<#= TKey #>, HeldState> heldAggregates;
     <# } else { #>
 
     [DataMember]
@@ -89,7 +89,7 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
         this.batch.Allocate();
 
         <# if (!this.isUngrouped) { #>
-        var generator = this.keyComparer.CreateFastDictionary3Generator<<#= TKey #>, HeldState>(1, this.keyComparerEquals, this.keyComparerGetHashCode, stream.Properties.QueryContainer);
+        var generator = this.keyComparer.CreateFastDictionaryGenerator<<#= TKey #>, HeldState>(1, this.keyComparerEquals, this.keyComparerGetHashCode, stream.Properties.QueryContainer);
         this.heldAggregates = generator.Invoke();
         <# } #>
     }
@@ -207,7 +207,7 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
                 }
                 <# } else { #>
 
-                    int iter1 = FastDictionary3<<#= TKey #>, HeldState>.IteratorStart;
+                    int iter1 = FastDictionary<<#= TKey #>, HeldState>.IteratorStart;
                     while (this.heldAggregates.Iterate(ref iter1))
                     {
                         var iter1entry = this.heldAggregates.entries[iter1];
@@ -217,7 +217,7 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
                         this.batch.vother.col[c] = iter1entry.value.timestamp + this.hop;
                         <#= assignToOutput(computeResult("iter1entry.value.state.state")) #>
                         this.batch.key.col[c] = iter1entry.key;
-                        this.batch.hash.col[c] = iter1entry.hash;
+                        this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                         this.batch.Count++;
                         if (this.batch.Count == Config.DataBatchSize) FlushContents();
                     }
@@ -260,7 +260,7 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
                     currentState.timestamp = syncTime;
                     // No output because initial state is empty
 
-                    this.heldAggregates.Insert(ref index, currentKey, currentState, currentHash);
+                    this.heldAggregates.Insert(ref index, currentKey, currentState);
                 }
                 else
                 {
@@ -329,7 +329,7 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
             }
             <# } else { #>
 
-            int iter1 = FastDictionary3<<#= TKey #>, HeldState>.IteratorStart;
+            int iter1 = FastDictionary<<#= TKey #>, HeldState>.IteratorStart;
             while (this.heldAggregates.Iterate(ref iter1))
             {
                 var iter1entry = this.heldAggregates.entries[iter1];
@@ -340,7 +340,7 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
                 <#= assignToOutput(computeResult("iter1entry.value.state.state")) #>
 
                 this.batch.key.col[c] = iter1entry.key;
-                this.batch.hash.col[c] = iter1entry.hash;
+                this.batch.hash.col[c] = this.keyComparerGetHashCode(iter1entry.key);
                 this.batch.Count++;
                 if (this.batch.Count == Config.DataBatchSize) FlushContents();
             }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Ungroup/UngroupPipe.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Ungroup/UngroupPipe.tt
@@ -35,6 +35,11 @@ namespace Microsoft.StreamProcessing
         [SchemaSerialization]
         private readonly Expression<Func<TInnerKey, TInnerResult, TResult>> resultSelectorExpr;
         private readonly Func<TInnerKey, TInnerResult, TResult> resultSelector;
+<# if (i == 0) { #>
+        [SchemaSerialization]
+        private readonly Expression<Func<TOuterKey, int>> keyComparer;
+        private readonly Func<TOuterKey, int> outerHashCode;
+<# } #>
 
         [Obsolete("Used only by serialization. Do not call directly.")]
         public <#= j == 0 ? "Partitioned" : string.Empty #>Ungroup<#= nestedInfix #>Pipe() { }
@@ -44,10 +49,14 @@ namespace Microsoft.StreamProcessing
             IStreamObserver<<#= outerKey #>, TResult> observer)
             : base(stream, observer)
         {
-            resultSelectorExpr = stream.ResultSelector;
-            resultSelector = resultSelectorExpr.Compile();
-            outPool = MemoryManager.GetMemoryPool<<#= outerKey #>, TResult>(stream.Properties.IsColumnar);
-            errorMessages = stream.ErrorMessages;
+            this.resultSelectorExpr = stream.ResultSelector;
+            this.resultSelector = this.resultSelectorExpr.Compile();
+            this.outPool = MemoryManager.GetMemoryPool<<#= outerKey #>, TResult>(stream.Properties.IsColumnar);
+            this.errorMessages = stream.ErrorMessages;
+<# if (i == 0) { #>
+            this.keyComparer = stream.Properties.KeyEqualityComparer.GetGetHashCodeExpr();
+            this.outerHashCode = this.keyComparer.Compile();
+<# } #>
         }
 
         public unsafe void OnNext(StreamMessage<<#= innerKey #>, TInnerResult> batch)
@@ -78,7 +87,7 @@ namespace Microsoft.StreamProcessing
                         {
                             destkey[i] = srckey[i].outerGroup;
                             desthash[i] = batch.hash.col[i];
-                            tmp.bitvector.col[i >> 6] |= (1L << (i & 0x3f));
+                            tmp.bitvector.col[i >> 6] |= 1L << (i & 0x3f);
                         }
                         continue;
                     }
@@ -87,7 +96,7 @@ namespace Microsoft.StreamProcessing
 <# } #>
                     destkey[i] = srckey[i].outerGroup;
                     tmp[i] = resultSelector(srckey[i].innerGroup, batch[i]);
-                    desthash[i] = destkey[i].GetHashCode();
+                    desthash[i] = this.outerHashCode(destkey[i]);
                 }
 <# } else { #>
                 Array.Clear(tmp.hash.col, 0, count);
@@ -114,8 +123,7 @@ namespace Microsoft.StreamProcessing
         }
 
         public override void ProduceQueryPlan(PlanNode previous)
-        {
-            Observer.ProduceQueryPlan(new UngroupPlanNode(
+            => Observer.ProduceQueryPlan(new UngroupPlanNode(
                 previous,
                 this,
                 typeof(<#= innerKey #>),
@@ -125,7 +133,6 @@ namespace Microsoft.StreamProcessing
                 resultSelectorExpr,
                 false,
                 errorMessages));
-        }
 
         public override int CurrentlyBufferedOutputCount => 0;
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Ungroup/UngroupTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Ungroup/UngroupTemplate.cs
@@ -71,10 +71,15 @@ using Microsoft.StreamProcessing.Internal.Collections;
             this.Write(">\r\n{\r\n    private readonly ");
             this.Write(this.ToStringHelper.ToStringWithCulture(memoryPoolClassName));
             this.Write(" outPool;\r\n    private readonly Func<PlanNode, IQueryObject, PlanNode> queryPlanG" +
-                    "enerator;\r\n");
+                    "enerator;\r\n\r\n");
  if (ungroupingToUnit) { 
-            this.Write("\r\n    private readonly ColumnBatch<Microsoft.StreamProcessing.Empty> unitColumn;\r" +
-                    "\n    private readonly ColumnBatch<int> unitHashColumn;\r\n");
+            this.Write("    private readonly ColumnBatch<Microsoft.StreamProcessing.Empty> unitColumn;\r\n " +
+                    "   private readonly ColumnBatch<int> unitHashColumn;\r\n");
+ } 
+ else { 
+            this.Write("    private readonly Func<");
+            this.Write(this.ToStringHelper.ToStringWithCulture(TOuterKey));
+            this.Write(", int> outerHashCode;\r\n");
  } 
  foreach (var f in this.unassignedFields) { 
             this.Write("    private readonly ColumnBatch<");
@@ -98,20 +103,25 @@ using Microsoft.StreamProcessing.Internal.Collections;
             this.Write(", ");
             this.Write(this.ToStringHelper.ToStringWithCulture(TResult));
             this.Write("> observer,\r\n        Func<PlanNode, IQueryObject, PlanNode> queryPlanGenerator)\r\n" +
-                    "        : base(stream, observer)\r\n    {\r\n        outPool = MemoryManager.GetMemo" +
-                    "ryPool<");
+                    "        : base(stream, observer)\r\n    {\r\n        this.outPool = MemoryManager.Ge" +
+                    "tMemoryPool<");
             this.Write(this.ToStringHelper.ToStringWithCulture(TOuterKey));
             this.Write(", ");
             this.Write(this.ToStringHelper.ToStringWithCulture(TResult));
             this.Write(">(true) as ");
             this.Write(this.ToStringHelper.ToStringWithCulture(memoryPoolClassName));
-            this.Write(";\r\n        this.queryPlanGenerator = queryPlanGenerator;\r\n");
+            this.Write(";\r\n        this.queryPlanGenerator = queryPlanGenerator;\r\n\r\n");
  if (ungroupingToUnit) { 
-            this.Write("\r\n        outPool.GetKey(out unitColumn);\r\n        outPool.Get(out unitHashColumn" +
-                    ");\r\n        Array.Clear(unitHashColumn.col, 0, unitHashColumn.col.Length);\r\n");
+            this.Write("        this.outPool.GetKey(out this.unitColumn);\r\n        this.outPool.Get(out t" +
+                    "his.unitHashColumn);\r\n        Array.Clear(this.unitHashColumn.col, 0, this.unitH" +
+                    "ashColumn.col.Length);\r\n");
+ } 
+ else { 
+            this.Write("        this.outerHashCode = stream.Properties.KeyEqualityComparer.GetGetHashCode" +
+                    "Expr().Compile();\r\n");
  } 
  foreach (var f in this.unassignedFields) { 
-            this.Write("        outPool.Get(out sharedDefaultColumnFor_");
+            this.Write("        this.outPool.Get(out sharedDefaultColumnFor_");
             this.Write(this.ToStringHelper.ToStringWithCulture(f.Name));
             this.Write(");\r\n        Array.Clear(sharedDefaultColumnFor_");
             this.Write(this.ToStringHelper.ToStringWithCulture(f.Name));
@@ -263,7 +273,7 @@ using Microsoft.StreamProcessing.Internal.Collections;
             this.Write("                    continue;\r\n                }\r\n");
      if (!ungroupingToUnit) { 
             this.Write("                destkey[i] = srckey[i].outerGroup;\r\n                desthash[i] =" +
-                    " destkey[i].GetHashCode();\r\n");
+                    " this.outerHashCode(destkey[i]);\r\n");
      } 
      foreach (var kv in this.computedFields) {
             var f = kv.Key;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Ungroup/UngroupTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Ungroup/UngroupTemplate.tt
@@ -38,10 +38,13 @@ internal sealed class <#= CLASSNAME #><#= genericParameters #> :
 {
     private readonly <#= memoryPoolClassName #> outPool;
     private readonly Func<PlanNode, IQueryObject, PlanNode> queryPlanGenerator;
-<# if (ungroupingToUnit) { #>
 
+<# if (ungroupingToUnit) { #>
     private readonly ColumnBatch<Microsoft.StreamProcessing.Empty> unitColumn;
     private readonly ColumnBatch<int> unitHashColumn;
+<# } #>
+<# else { #>
+    private readonly Func<<#= TOuterKey #>, int> outerHashCode;
 <# } #>
 <# foreach (var f in this.unassignedFields) { #>
     private readonly ColumnBatch<<#= f.TypeName #>> sharedDefaultColumnFor_<#= f.Name #>;
@@ -57,16 +60,19 @@ internal sealed class <#= CLASSNAME #><#= genericParameters #> :
         Func<PlanNode, IQueryObject, PlanNode> queryPlanGenerator)
         : base(stream, observer)
     {
-        outPool = MemoryManager.GetMemoryPool<<#= TOuterKey #>, <#= TResult #>>(true) as <#= memoryPoolClassName #>;
+        this.outPool = MemoryManager.GetMemoryPool<<#= TOuterKey #>, <#= TResult #>>(true) as <#= memoryPoolClassName #>;
         this.queryPlanGenerator = queryPlanGenerator;
-<# if (ungroupingToUnit) { #>
 
-        outPool.GetKey(out unitColumn);
-        outPool.Get(out unitHashColumn);
-        Array.Clear(unitHashColumn.col, 0, unitHashColumn.col.Length);
+<# if (ungroupingToUnit) { #>
+        this.outPool.GetKey(out this.unitColumn);
+        this.outPool.Get(out this.unitHashColumn);
+        Array.Clear(this.unitHashColumn.col, 0, this.unitHashColumn.col.Length);
+<# } #>
+<# else { #>
+        this.outerHashCode = stream.Properties.KeyEqualityComparer.GetGetHashCodeExpr().Compile();
 <# } #>
 <# foreach (var f in this.unassignedFields) { #>
-        outPool.Get(out sharedDefaultColumnFor_<#= f.Name #>);
+        this.outPool.Get(out sharedDefaultColumnFor_<#= f.Name #>);
         Array.Clear(sharedDefaultColumnFor_<#= f.Name #>.col, 0, sharedDefaultColumnFor_<#= f.Name #>.col.Length);
 <# } #>
     }
@@ -185,7 +191,7 @@ internal sealed class <#= CLASSNAME #><#= genericParameters #> :
                 }
 <#     if (!ungroupingToUnit) { #>
                 destkey[i] = srckey[i].outerGroup;
-                desthash[i] = destkey[i].GetHashCode();
+                desthash[i] = this.outerHashCode(destkey[i]);
 <#     } #>
 <#     foreach (var kv in this.computedFields) {
             var f = kv.Key;

--- a/Sources/Core/Microsoft.StreamProcessing/Pipes/Pipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Pipes/Pipe.cs
@@ -51,7 +51,7 @@ namespace Microsoft.StreamProcessing
         }
 
         private int GetSchemaHashCode()
-            => this.schemaFields.Value.Aggregate(GetType().ToString().GetHashCode(), (a, f) => a ^ (f.GetValue(this) ?? string.Empty).ToString().GetHashCode());
+            => this.schemaFields.Value.Aggregate(GetType().ToString().StableHash(), (a, f) => a ^ (f.GetValue(this) ?? string.Empty).ToString().StableHash());
 
         private object Serializer => this.container?.GetOrCreateSerializer(GetType());
 

--- a/Sources/Core/Microsoft.StreamProcessing/Serializer/GeneratedSubtypes/FastDictionaryGenerator.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Serializer/GeneratedSubtypes/FastDictionaryGenerator.cs
@@ -27,9 +27,9 @@ namespace Microsoft.StreamProcessing.Internal
             var equalsExp = comparerExp.GetEqualsExpr();
             var getHashCodeExp = comparerExp.GetGetHashCodeExpr();
             var vars = VariableFinder.Find(equalsExp).Select(o => o.GetHashCode()).ToList();
-            if (!vars.Any()) vars.Add(string.Empty.GetHashCode());
+            if (!vars.Any()) vars.Add(string.Empty.StableHash());
             var hashvars = VariableFinder.Find(getHashCodeExp).Select(o => o.GetHashCode()).ToList();
-            if (!hashvars.Any()) hashvars.Add(string.Empty.GetHashCode());
+            if (!hashvars.Any()) hashvars.Add(string.Empty.StableHash());
             var key =
                 Tuple.Create(
                     equalsExp.ToString() + getHashCodeExp.ToString() + string.Concat(vars.Aggregate((a, i) => a ^ i)) + string.Concat(hashvars.Aggregate((a, i) => a ^ i)),
@@ -74,9 +74,9 @@ namespace Microsoft.StreamProcessing.Internal
             var equalsExp = comparerExp.GetEqualsExpr();
             var getHashCodeExp = comparerExp.GetGetHashCodeExpr();
             var vars = VariableFinder.Find(equalsExp).Select(o => o.GetHashCode()).ToList();
-            if (!vars.Any()) vars.Add(string.Empty.GetHashCode());
+            if (!vars.Any()) vars.Add(string.Empty.StableHash());
             var hashvars = VariableFinder.Find(getHashCodeExp).Select(o => o.GetHashCode()).ToList();
-            if (!hashvars.Any()) hashvars.Add(string.Empty.GetHashCode());
+            if (!hashvars.Any()) hashvars.Add(string.Empty.StableHash());
             var key =
                 Tuple.Create(
                     equalsExp.ToString() + getHashCodeExp.ToString() + string.Concat(vars.Aggregate((a, i) => a ^ i)) + string.Concat(hashvars.Aggregate((a, i) => a ^ i)),
@@ -121,9 +121,9 @@ namespace Microsoft.StreamProcessing.Internal
             var equalsExp = comparerExp.GetEqualsExpr();
             var getHashCodeExp = comparerExp.GetGetHashCodeExpr();
             var vars = VariableFinder.Find(equalsExp).Select(o => o.GetHashCode()).ToList();
-            if (!vars.Any()) vars.Add(string.Empty.GetHashCode());
+            if (!vars.Any()) vars.Add(string.Empty.StableHash());
             var hashvars = VariableFinder.Find(getHashCodeExp).Select(o => o.GetHashCode()).ToList();
-            if (!hashvars.Any()) hashvars.Add(string.Empty.GetHashCode());
+            if (!hashvars.Any()) hashvars.Add(string.Empty.StableHash());
             var key =
                 Tuple.Create(
                     equalsExp.ToString() + getHashCodeExp.ToString() + string.Concat(vars.Aggregate((a, i) => a ^ i)) + string.Concat(hashvars.Aggregate((a, i) => a ^ i)),

--- a/Sources/Core/Microsoft.StreamProcessing/Serializer/GeneratedSubtypes/FastDictionaryGenerator.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Serializer/GeneratedSubtypes/FastDictionaryGenerator.tt
@@ -37,9 +37,9 @@ foreach (var t in new[] {string.Empty, "2", "3"})
             var equalsExp = comparerExp.GetEqualsExpr();
             var getHashCodeExp = comparerExp.GetGetHashCodeExpr();
             var vars = VariableFinder.Find(equalsExp).Select(o => o.GetHashCode()).ToList();
-            if (!vars.Any()) vars.Add(string.Empty.GetHashCode());
+            if (!vars.Any()) vars.Add(string.Empty.StableHash());
             var hashvars = VariableFinder.Find(getHashCodeExp).Select(o => o.GetHashCode()).ToList();
-            if (!hashvars.Any()) hashvars.Add(string.Empty.GetHashCode());
+            if (!hashvars.Any()) hashvars.Add(string.Empty.StableHash());
             var key =
                 Tuple.Create(
                     equalsExp.ToString() + getHashCodeExp.ToString() + string.Concat(vars.Aggregate((a, i) => a ^ i)) + string.Concat(hashvars.Aggregate((a, i) => a ^ i)),

--- a/Sources/Core/Microsoft.StreamProcessing/Serializer/GeneratedSubtypes/SortedDictionaryGenerator.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Serializer/GeneratedSubtypes/SortedDictionaryGenerator.cs
@@ -32,7 +32,7 @@ namespace Microsoft.StreamProcessing.Internal
 
             var expression = expr.ToString();
             var vars = VariableFinder.Find(expr).Select(o => o.GetHashCode());
-            var captures = vars.Aggregate(expression.GetHashCode(), (a, i) => a ^ i);
+            var captures = vars.Aggregate(expression.StableHash(), (a, i) => a ^ i);
             var key = Tuple.Create(expression + string.Concat(vars.Select(o => o.ToString(CultureInfo.InvariantCulture))), typeof(TKey), typeof(TValue));
 
             Type temp;
@@ -42,8 +42,8 @@ namespace Microsoft.StreamProcessing.Internal
                 {
                     string typeName = Prefix
                         + captures.ToString(CultureInfo.InvariantCulture)
-                        + typeof(TKey).ToString().GetHashCode().ToString(CultureInfo.InvariantCulture)
-                        + typeof(TValue).ToString().GetHashCode().ToString(CultureInfo.InvariantCulture);
+                        + typeof(TKey).ToString().StableHash().ToString(CultureInfo.InvariantCulture)
+                        + typeof(TValue).ToString().StableHash().ToString(CultureInfo.InvariantCulture);
                     typeName = typeName.Replace("-", "_");
                     var builderCode = new GeneratedSortedDictionary(typeName).TransformText();
                     var assemblyReferences = Transformer.AssemblyReferencesNeededFor(typeof(SortedDictionary<,>));

--- a/Sources/Core/Microsoft.StreamProcessing/StreamProcessing.nuspec
+++ b/Sources/Core/Microsoft.StreamProcessing/StreamProcessing.nuspec
@@ -14,7 +14,7 @@
     <tags>Streaming Temporal Data</tags>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.CodeAnalysis.Scripting" version="2.9.0" />
+        <dependency id="Microsoft.CodeAnalysis.Scripting" version="2.10.0" />
         <dependency id="Microsoft.CSharp" version="4.5.0" />
         <dependency id="NETStandard.Library" version="2.0.0" />
         <dependency id="System.Diagnostics.Contracts" version="4.3.0" />
@@ -24,7 +24,7 @@
         <dependency id="System.Threading.Thread" version="4.3.0" />
       </group>
       <group targetFramework="net46">
-        <dependency id="Microsoft.CodeAnalysis.Scripting" version="2.9.0" />
+        <dependency id="Microsoft.CodeAnalysis.Scripting" version="2.10.0" />
         <dependency id="Microsoft.CSharp" version="4.5.0" />
         <dependency id="System.Diagnostics.Contracts" version="4.3.0" />
         <dependency id="System.Diagnostics.Process" version="4.3.0" />

--- a/Sources/Core/Microsoft.StreamProcessing/Utilities/EqualityComparerExpression.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Utilities/EqualityComparerExpression.cs
@@ -57,7 +57,7 @@ namespace Microsoft.StreamProcessing
 
         public static bool TryGetCachedComparer<T>(out IEqualityComparerExpression<T> comparer)
         {
-            Type t = typeof(T);
+            var t = typeof(T);
             comparer = null;
             if (typeComparerCache.TryGetValue(t, out object temp))
             {
@@ -81,7 +81,7 @@ namespace Microsoft.StreamProcessing
 
         public static bool TryGetCachedGetHashCodeFunction<T>(out Func<T, int> getHashCodeFunction)
         {
-            Type t = typeof(T);
+            var t = typeof(T);
             getHashCodeFunction = null;
             if (getHashCodeCache.TryGetValue(t, out object temp))
             {
@@ -443,7 +443,7 @@ namespace Microsoft.StreamProcessing
         }
     }
 
-    internal class GenericEqualityComparerExpression<T> : EqualityComparerExpression<T>
+    internal sealed class GenericEqualityComparerExpression<T> : EqualityComparerExpression<T>
     {
         public GenericEqualityComparerExpression()
             : base(

--- a/Sources/Core/Microsoft.StreamProcessing/Utilities/EqualityComparerExpression.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Utilities/EqualityComparerExpression.cs
@@ -489,7 +489,7 @@ namespace Microsoft.StreamProcessing
         public StringEqualityComparerExpression()
             : base(
                   equalsExpr: (x, y) => x == y,
-                  getHashCodeExpr: obj => obj == null ? 0 : obj.GetHashCode())
+                  getHashCodeExpr: obj => obj == null ? 0 : obj.StableHash())
         { }
     }
 


### PR DESCRIPTION
(sigh)

.Net Core does not have a string hash code method that is deterministic across process boundaries. The claim is that there is a vulnerability otherwise, but the impact on Trill is that one cannot have any hash code values in state checkpoints that then get restored into another process.

This change:
- Introduces a string GetHashCode method that is stable.
- Has the default implementation of IEqualityComparerExpression use the new hash method for strings
- Change any reference to string.GetHashCode to either use IEqualityComparerExpression or to call directly to the new hash code method.