### PR TITLE
Allow multiple subsequent subscriptions on BinaryIngressStreamable

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Ingress/Binary/BinaryIngressReader.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Ingress/Binary/BinaryIngressReader.cs
@@ -17,6 +17,7 @@ namespace Microsoft.StreamProcessing
         private readonly int numMessages;
         private readonly Stream stream;
         private readonly IIngressScheduler scheduler;
+        private readonly Action onSubscriptionCompleted;
 
         [Obsolete("Used only by serialization. Do not call directly.")]
         public BinaryIngressReader() { }
@@ -28,13 +29,15 @@ namespace Microsoft.StreamProcessing
             int numMessages,
             Stream stream,
             IIngressScheduler scheduler,
-            bool delayed)
+            bool delayed,
+            Action onSubscriptionCompleted)
             : base(identifier, streamable, observer)
         {
             this.pool = MemoryManager.GetMemoryPool<TKey, TPayload>();
             this.numMessages = numMessages;
             this.stream = stream;
             this.scheduler = scheduler;
+            this.onSubscriptionCompleted = onSubscriptionCompleted;
 
             if (!delayed) this.subscription.Enable();
         }
@@ -82,6 +85,8 @@ namespace Microsoft.StreamProcessing
             {
                 observer.OnError(e);
             }
+
+            this.onSubscriptionCompleted();
         }
     }
 }

--- a/Sources/Test/SimpleTesting/AdHocTests.cs
+++ b/Sources/Test/SimpleTesting/AdHocTests.cs
@@ -550,6 +550,39 @@ namespace SimpleTesting
 
             Assert.IsTrue(inputData.SequenceEqual(output));
         }
+
+        [TestMethod, TestCategory("Gated")]
+        public void FileStreamDoubleQuery()
+        {
+            const bool serializeStreamProperties = true;
+
+            string filePath = $"{Path.GetTempPath()}\\{nameof(FileStreamDoubleQuery)}.bin";
+            const int inputEventCount = 100;
+            var inputData = Enumerable.Range(0, inputEventCount)
+                .Select(e => StreamEvent.CreatePoint<long>(0, e))
+                .ToList();
+            var input = inputData.ToObservable().ToStreamable();
+
+            // Stream to file
+            using (var stream = File.Create(filePath))
+            {
+                input.ToBinaryStream(stream, writePropertiesToStream: serializeStreamProperties);
+            }
+
+            // Stream from file, twice. This should be supported for streams that support Seek.
+            using (var stream = File.OpenRead(filePath))
+            {
+                Assert.IsTrue(stream.CanSeek);
+
+                var streamable = stream.ToStreamable<long>(readPropertiesFromStream: serializeStreamProperties);
+                for (int i = 0; i < 2; i++)
+                {
+                    var output = new List<StreamEvent<long>>();
+                    streamable.ToStreamEventObservable().Where(e => e.IsData).ForEachAsync(e => output.Add(e)).Wait();
+                    Assert.IsTrue(inputData.SequenceEqual(output));
+                }
+            }
+        }
     }
 
     [TestClass]


### PR DESCRIPTION
Allowing multiple subsequent subscriptions on a single BinaryIngressStreamable instance for streams that support Seek operations. This addresses issue #46 .

Note that due to the current Stream API, I don't see a way to support concurrent subscriptions on a single BinaryIngressStreamable instance.