### PR TITLE
Addressing a shortcoming in how ingress methods dispose when manually…

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Ingress/Atemporal/AtemporalIngressSubscription.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Ingress/Atemporal/AtemporalIngressSubscription.cs
@@ -90,6 +90,8 @@ namespace Microsoft.StreamProcessing
                     this.timer.Dispose();
                     this.timer = null;
                 }
+
+                base.DisposeState();
             }
         }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Ingress/Atemporal/AtemporalIngressSubscription.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Ingress/Atemporal/AtemporalIngressSubscription.tt
@@ -133,6 +133,8 @@ namespace Microsoft.StreamProcessing
                     this.timer.Dispose();
                     this.timer = null;
                 }
+
+                base.DisposeState();
             }
         }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Ingress/SubscriptionBase.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Ingress/SubscriptionBase.cs
@@ -100,11 +100,6 @@ namespace Microsoft.StreamProcessing.Internal
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class DisorderedSubscriptionBase<TIngressStructure, TPayload, TResult> : Pipe<Empty, TResult>, IIngressStreamObserver
     {
-        /// <summary>
-        /// Currently for internal use only - do not use directly.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected IDisposable disposer;
         private readonly string errorMessages;
         private new readonly bool isColumnar;
 
@@ -365,10 +360,10 @@ namespace Microsoft.StreamProcessing.Internal
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void DisposeState()
         {
+            this.subscription?.Dispose();
+            this.impatienceSorter?.Dispose();
             this.currentBatch?.Free();
             this.currentBatch = null;
-            this.impatienceSorter?.Dispose();
-            this.disposer?.Dispose();
         }
 
         /// <summary>
@@ -595,11 +590,6 @@ namespace Microsoft.StreamProcessing.Internal
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class SubscriptionBase<TIngressStructure, TPayload, TResult> : Pipe<Empty, TResult>, IIngressStreamObserver
     {
-        /// <summary>
-        /// Currently for internal use only - do not use directly.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected IDisposable disposer;
         private readonly string errorMessages;
         private new readonly bool isColumnar;
 
@@ -860,10 +850,10 @@ namespace Microsoft.StreamProcessing.Internal
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void DisposeState()
         {
+            this.subscription?.Dispose();
+            this.impatienceSorter?.Dispose();
             this.currentBatch?.Free();
             this.currentBatch = null;
-            this.impatienceSorter?.Dispose();
-            this.disposer?.Dispose();
         }
 
         /// <summary>
@@ -1095,11 +1085,6 @@ namespace Microsoft.StreamProcessing.Internal
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class DisorderedPartitionedSubscriptionBase<TKey, TIngressStructure, TPayload, TResult> : Pipe<PartitionKey<TKey>, TResult>, IIngressStreamObserver
     {
-        /// <summary>
-        /// Currently for internal use only - do not use directly.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected IDisposable disposer;
         private readonly string errorMessages;
         private new readonly bool isColumnar;
 
@@ -1406,10 +1391,10 @@ namespace Microsoft.StreamProcessing.Internal
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void DisposeState()
         {
+            this.subscription?.Dispose();
+            this.impatienceSorter?.Dispose();
             this.currentBatch?.Free();
             this.currentBatch = null;
-            this.impatienceSorter?.Dispose();
-            this.disposer?.Dispose();
         }
 
         /// <summary>
@@ -1641,11 +1626,6 @@ namespace Microsoft.StreamProcessing.Internal
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class PartitionedSubscriptionBase<TKey, TIngressStructure, TPayload, TResult> : Pipe<PartitionKey<TKey>, TResult>, IIngressStreamObserver
     {
-        /// <summary>
-        /// Currently for internal use only - do not use directly.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected IDisposable disposer;
         private readonly string errorMessages;
         private new readonly bool isColumnar;
 
@@ -1952,10 +1932,10 @@ namespace Microsoft.StreamProcessing.Internal
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void DisposeState()
         {
+            this.subscription?.Dispose();
+            this.impatienceSorter?.Dispose();
             this.currentBatch?.Free();
             this.currentBatch = null;
-            this.impatienceSorter?.Dispose();
-            this.disposer?.Dispose();
         }
 
         /// <summary>

--- a/Sources/Core/Microsoft.StreamProcessing/Ingress/SubscriptionBase.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Ingress/SubscriptionBase.tt
@@ -137,11 +137,6 @@ foreach (bool disordered in new[] { true, false })
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class <#= disordered ? "Disordered" : string.Empty #><#= partitionString #>SubscriptionBase<<#= genericArgument #>TIngressStructure, TPayload, TResult> : Pipe<<#= baseType #>, TResult>, IIngressStreamObserver
     {
-        /// <summary>
-        /// Currently for internal use only - do not use directly.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected IDisposable disposer;
         private readonly string errorMessages;
         private new readonly bool isColumnar;
 
@@ -511,10 +506,10 @@ foreach (bool disordered in new[] { true, false })
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void DisposeState()
         {
+            this.subscription?.Dispose();
+            this.impatienceSorter?.Dispose();
             this.currentBatch?.Free();
             this.currentBatch = null;
-            this.impatienceSorter?.Dispose();
-            this.disposer?.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
… called. Somewhere in the edit history the field "disposer" and the underlying subscription object had become decoupled. This change eliminates the "disposer" field and calls dispose directly on the subscription object.

This fix addresses issue #45 