### PR TITLE
Making sure that default register is actually used instead 

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/AfaDescriptor.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/AfaDescriptor.cs
@@ -37,7 +37,6 @@ namespace Microsoft.StreamProcessing
             => new Afa<TInput, TRegister>(defaultRegister);
     }
 
-
     /// <summary>
     /// Class that describes an AFA completely, along with its properties.
     /// </summary>
@@ -282,7 +281,6 @@ namespace Microsoft.StreamProcessing
         /// </summary>
         /// <param name="defaultRegister">The default value for the register</param>
         public Afa(TRegister defaultRegister = default) : base(defaultRegister)
-        {
-        }
+        { }
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/AfaMultiEventListTransformer.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/AfaMultiEventListTransformer.cs
@@ -82,14 +82,11 @@ namespace Microsoft.StreamProcessing
                                 Accumulate = (ts, ev, reg, acc) => multiArc.Accumulate.Inline(ts, ev, reg, acc),
                                 Fence = (ts, acc, reg) => multiArc.Fence.Inline(ts, acc, reg),
                             };
-                            if (multiArc.Transfer == null)
-                            {
-                                multiEdgeInfo.Transfer = null;
-                            }
-                            else
-                            {
-                                multiEdgeInfo.Transfer = (ts, acc, reg) => multiArc.Transfer.Inline(ts, acc, reg);
-                            }
+
+                            multiEdgeInfo.Transfer = multiArc.Transfer == null
+                                ? (Func<string, string, string, string>)null
+                                : ((ts, acc, reg) => multiArc.Transfer.Inline(ts, acc, reg));
+
                             if (multiArc.Dispose == null)
                             {
                                 multiEdgeInfo.Dispose = (acc) => "// no dispose function";
@@ -98,14 +95,10 @@ namespace Microsoft.StreamProcessing
                             {
                                 multiEdgeInfo.Dispose = (acc) => multiArc.Dispose.Inline(acc);
                             }
-                            if (multiArc.SkipToEnd == null)
-                            {
-                                multiEdgeInfo.SkipToEnd = null;
-                            }
-                            else
-                            {
-                                multiEdgeInfo.SkipToEnd = (ts, ev, acc) => multiArc.SkipToEnd.Inline(ts, ev, acc);
-                            }
+
+                            multiEdgeInfo.SkipToEnd = multiArc.SkipToEnd == null
+                                ? (Func<string, string, string, string>)null
+                                : ((ts, ev, acc) => multiArc.SkipToEnd.Inline(ts, ev, acc));
 
                             edgeList.Add(multiEdgeInfo);
                             continue;
@@ -149,14 +142,11 @@ namespace Microsoft.StreamProcessing
                                 Accumulate = (ts, ev, reg, acc) => multiArc.Accumulate.Inline(ts, ev, reg, acc),
                                 Fence = (ts, acc, reg) => multiArc.Fence.Inline(ts, acc, reg),
                             };
-                            if (multiArc.Transfer == null)
-                            {
-                                multiEdgeInfo.Transfer = null;
-                            }
-                            else
-                            {
-                                multiEdgeInfo.Transfer = (ts, acc, reg) => multiArc.Transfer.Inline(ts, acc, reg);
-                            }
+
+                            multiEdgeInfo.Transfer = multiArc.Transfer == null
+                                ? (Func<string, string, string, string>)null
+                                : ((ts, acc, reg) => multiArc.Transfer.Inline(ts, acc, reg));
+
                             if (multiArc.Dispose == null)
                             {
                                 multiEdgeInfo.Dispose = (acc) => "// no dispose function";
@@ -165,14 +155,11 @@ namespace Microsoft.StreamProcessing
                             {
                                 multiEdgeInfo.Dispose = (acc) => multiArc.Dispose.Inline(acc);
                             }
-                            if (multiArc.SkipToEnd == null)
-                            {
-                                multiEdgeInfo.SkipToEnd = null;
-                            }
-                            else
-                            {
-                                multiEdgeInfo.SkipToEnd = (ts, ev, acc) => multiArc.SkipToEnd.Inline(ts, ev, acc);
-                            }
+
+                            multiEdgeInfo.SkipToEnd = multiArc.SkipToEnd == null
+                                ? (Func<string, string, string, string>)null
+                                : ((ts, ev, acc) => multiArc.SkipToEnd.Inline(ts, ev, acc));
+
                             edgeList2.Add(multiEdgeInfo);
                             continue;
                         }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_EventList.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_EventList.cs
@@ -87,11 +87,10 @@ namespace Microsoft.StreamProcessing
 
                                     if (arcinfo.Fence(synctime, currentList.payloads, state.register))
                                     {
-                                        TRegister newReg;
-                                        if (arcinfo.Transfer == null) newReg = state.register;
-                                        else newReg = arcinfo.Transfer(synctime, currentList.payloads, state.register);
-
-                                        int ns = arcinfo.toState;
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, currentList.payloads, state.register);
+                                            int ns = arcinfo.toState;
                                         while (true)
                                         {
                                             if (this.isFinal[ns])
@@ -103,10 +102,7 @@ namespace Microsoft.StreamProcessing
                                                 this.batch.hash.col[this.iter] = el_hash;
                                                 this.iter++;
 
-                                                if (this.iter == Config.DataBatchSize)
-                                                {
-                                                    FlushContents();
-                                                }
+                                                if (this.iter == Config.DataBatchSize) FlushContents();
                                             }
 
                                             if (this.hasOutgoingArcs[ns])
@@ -151,10 +147,9 @@ namespace Microsoft.StreamProcessing
 
                                         if (arcinfo.Fence(synctime, currentList.payloads[0], state.register))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = state.register;
-                                            else newReg = arcinfo.Transfer(synctime, currentList.payloads[0], state.register);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, currentList.payloads[0], state.register);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {
@@ -167,10 +162,7 @@ namespace Microsoft.StreamProcessing
                                                     this.batch.hash.col[this.iter] = el_hash;
                                                     this.iter++;
 
-                                                    if (this.iter == Config.DataBatchSize)
-                                                    {
-                                                        FlushContents();
-                                                    }
+                                                    if (this.iter == Config.DataBatchSize) FlushContents();
                                                 }
 
                                                 if (this.hasOutgoingArcs[ns])
@@ -217,59 +209,54 @@ namespace Microsoft.StreamProcessing
                     #region eventListStateMap
                     if (this.eventListStateMap != null)
                     {
-                    var startStateMap = this.eventListStateMap[startState];
-                    if (startStateMap != null)
-                    {
-                        var m = startStateMap.Length;
-                        for (int cnt = 0; cnt < m; cnt++)
+                        var startStateMap = this.eventListStateMap[startState];
+                        if (startStateMap != null)
                         {
-                            var arcinfo = startStateMap[cnt];
-                            if (arcinfo.Fence(synctime, currentList.payloads, this.defaultRegister))
+                            var m = startStateMap.Length;
+                            for (int cnt = 0; cnt < m; cnt++)
                             {
-                                TRegister newReg;
-                                if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                else newReg = arcinfo.Transfer(synctime, currentList.payloads, this.defaultRegister);
-
-                                int ns = arcinfo.toState;
-                                while (true)
+                                var arcinfo = startStateMap[cnt];
+                                if (arcinfo.Fence(synctime, currentList.payloads, this.defaultRegister))
                                 {
-                                    if (this.isFinal[ns])
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, currentList.payloads, this.defaultRegister);
+                                    int ns = arcinfo.toState;
+                                    while (true)
                                     {
-                                        this.batch.vsync.col[this.iter] = synctime;
-                                        this.batch.vother.col[this.iter] = synctime + this.MaxDuration;
-                                        this.batch[this.iter] = newReg;
-                                        this.batch.key.col[this.iter] = currentList.key;
-                                        this.batch.hash.col[this.iter] = el_hash;
-                                        this.iter++;
-
-                                        if (this.iter == Config.DataBatchSize)
+                                        if (this.isFinal[ns])
                                         {
-                                            FlushContents();
+                                            this.batch.vsync.col[this.iter] = synctime;
+                                            this.batch.vother.col[this.iter] = synctime + this.MaxDuration;
+                                            this.batch[this.iter] = newReg;
+                                            this.batch.key.col[this.iter] = currentList.key;
+                                            this.batch.hash.col[this.iter] = el_hash;
+                                            this.iter++;
+
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
-                                    }
-                                    if (this.hasOutgoingArcs[ns])
-                                    {
-                                        int index = this.activeStates.Insert(el_hash);
-                                        this.activeStates.Values[index].key = currentList.key;
-                                        this.activeStates.Values[index].state = ns;
-                                        this.activeStates.Values[index].register = newReg;
-                                        this.activeStates.Values[index].PatternStartTimestamp = synctime;
-
-
-                                        // Add epsilon arc destinations to stack
-                                        if (this.epsilonStateMap == null) break;
-                                        if (this.epsilonStateMap[ns] != null)
+                                        if (this.hasOutgoingArcs[ns])
                                         {
-                                            for (int cnt2 = 0; cnt2 < this.epsilonStateMap[ns].Length; cnt2++) this.stack.Push(this.epsilonStateMap[ns][cnt2]);
+                                            int index = this.activeStates.Insert(el_hash);
+                                            this.activeStates.Values[index].key = currentList.key;
+                                            this.activeStates.Values[index].state = ns;
+                                            this.activeStates.Values[index].register = newReg;
+                                            this.activeStates.Values[index].PatternStartTimestamp = synctime;
+
+                                            // Add epsilon arc destinations to stack
+                                            if (this.epsilonStateMap == null) break;
+                                            if (this.epsilonStateMap[ns] != null)
+                                            {
+                                                for (int cnt2 = 0; cnt2 < this.epsilonStateMap[ns].Length; cnt2++) this.stack.Push(this.epsilonStateMap[ns][cnt2]);
+                                            }
                                         }
+                                        if (this.stack.Count == 0) break;
+                                        ns = this.stack.Pop();
                                     }
-                                    if (this.stack.Count == 0) break;
-                                    ns = this.stack.Pop();
+                                    if (this.IsDeterministic) break; // We are guaranteed to have only one successful transition
                                 }
-                                if (this.IsDeterministic) break; // We are guaranteed to have only one successful transition
                             }
                         }
-                    }
                     }
                     #endregion
 
@@ -286,10 +273,9 @@ namespace Microsoft.StreamProcessing
                                 var arcinfo = startStateMap[cnt];
                                 if (arcinfo.Fence(synctime, currentList.payloads[0], this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, currentList.payloads[0], this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, currentList.payloads[0], this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -302,10 +288,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = el_hash;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_MultiEventList.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_MultiEventList.cs
@@ -86,7 +86,7 @@ namespace Microsoft.StreamProcessing
                                     {
                                         var arcinfo = currentStateMap[cnt];
 
-                                        TAccumulator acc = arcinfo.Initialize(synctime, state.register);
+                                        var acc = arcinfo.Initialize(synctime, state.register);
                                         for (int i = 0; i < currentList.payloads.Count; i++)
                                         {
                                             var payload = currentList.payloads[i];
@@ -96,10 +96,9 @@ namespace Microsoft.StreamProcessing
 
                                         if (arcinfo.Fence(synctime, acc, state.register))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = state.register;
-                                            else newReg = arcinfo.Transfer(synctime, acc, state.register);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, acc, state.register);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {
@@ -112,10 +111,7 @@ namespace Microsoft.StreamProcessing
                                                     this.batch.hash.col[this.iter] = el_hash;
                                                     this.iter++;
 
-                                                    if (this.iter == Config.DataBatchSize)
-                                                    {
-                                                        FlushContents();
-                                                    }
+                                                    if (this.iter == Config.DataBatchSize) FlushContents();
                                                 }
 
                                                 if (this.hasOutgoingArcs[ns])
@@ -162,10 +158,9 @@ namespace Microsoft.StreamProcessing
 
                                         if (arcinfo.Fence(synctime, item, state.register))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = state.register;
-                                            else newReg = arcinfo.Transfer(synctime, item, state.register);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, item, state.register);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {
@@ -178,10 +173,7 @@ namespace Microsoft.StreamProcessing
                                                     this.batch.hash.col[this.iter] = el_hash;
                                                     this.iter++;
 
-                                                    if (this.iter == Config.DataBatchSize)
-                                                    {
-                                                        FlushContents();
-                                                    }
+                                                    if (this.iter == Config.DataBatchSize) FlushContents();
                                                 }
 
                                                 if (this.hasOutgoingArcs[ns])
@@ -236,10 +228,9 @@ namespace Microsoft.StreamProcessing
 
                                         if (arcinfo.Fence(synctime, payloadList, state.register))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = state.register;
-                                            else newReg = arcinfo.Transfer(synctime, payloadList, state.register);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, payloadList, state.register);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {
@@ -252,10 +243,7 @@ namespace Microsoft.StreamProcessing
                                                     this.batch.hash.col[this.iter] = el_hash;
                                                     this.iter++;
 
-                                                    if (this.iter == Config.DataBatchSize)
-                                                    {
-                                                        FlushContents();
-                                                    }
+                                                    if (this.iter == Config.DataBatchSize) FlushContents();
                                                 }
 
                                                 if (this.hasOutgoingArcs[ns])
@@ -310,7 +298,7 @@ namespace Microsoft.StreamProcessing
                             {
                                 var arcinfo = startStateMap[cnt];
 
-                                TAccumulator acc = arcinfo.Initialize(synctime, this.defaultRegister);
+                                var acc = arcinfo.Initialize(synctime, this.defaultRegister);
                                 for (int i = 0; i < currentList.payloads.Count; i++)
                                 {
                                     var payload = currentList.payloads[i];
@@ -320,10 +308,9 @@ namespace Microsoft.StreamProcessing
 
                                 if (arcinfo.Fence(synctime, acc, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, acc, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, acc, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -336,10 +323,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = el_hash;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {
@@ -383,10 +367,9 @@ namespace Microsoft.StreamProcessing
 
                                 if (arcinfo.Fence(synctime, item, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, item, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, item, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -399,10 +382,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = el_hash;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {
@@ -453,10 +433,9 @@ namespace Microsoft.StreamProcessing
 
                                 if (arcinfo.Fence(synctime, payloadList, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, payloadList, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, payloadList, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -469,10 +448,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = el_hash;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_SingleEvent.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_SingleEvent.cs
@@ -172,10 +172,9 @@ namespace Microsoft.StreamProcessing
 
                                                 if (arcinfo.Fence(synctime, batch[i], state.register))
                                                 {
-                                                    TRegister newReg;
-                                                    if (arcinfo.Transfer == null) newReg = state.register;
-                                                    else newReg = arcinfo.Transfer(synctime, batch[i], state.register);
-
+                                                    var newReg = arcinfo.Transfer == null
+                                                        ? state.register
+                                                        : arcinfo.Transfer(synctime, batch[i], state.register);
                                                     int ns = arcinfo.toState;
                                                     while (true)
                                                     {
@@ -256,10 +255,9 @@ namespace Microsoft.StreamProcessing
                                         var arcinfo = startStateMap[cnt];
                                         if (arcinfo.Fence(synctime, batch[i], this.defaultRegister))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                            else newReg = arcinfo.Transfer(synctime, batch[i], this.defaultRegister);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? this.defaultRegister
+                                                : arcinfo.Transfer(synctime, batch[i], this.defaultRegister);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_EventList.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_EventList.cs
@@ -89,11 +89,10 @@ namespace Microsoft.StreamProcessing
 
                                     if (arcinfo.Fence(synctime, currentList.payloads, state.register))
                                     {
-                                        TRegister newReg;
-                                        if (arcinfo.Transfer == null) newReg = state.register;
-                                        else newReg = arcinfo.Transfer(synctime, currentList.payloads, state.register);
-
-                                        int ns = arcinfo.toState;
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, currentList.payloads, state.register);
+                                            int ns = arcinfo.toState;
                                         while (true)
                                         {
                                             if (this.isFinal[ns])
@@ -105,10 +104,7 @@ namespace Microsoft.StreamProcessing
                                                 this.batch.hash.col[this.iter] = el_hash;
                                                 this.iter++;
 
-                                                if (this.iter == Config.DataBatchSize)
-                                                {
-                                                    FlushContents();
-                                                }
+                                                if (this.iter == Config.DataBatchSize) FlushContents();
                                             }
 
                                             if (this.hasOutgoingArcs[ns])
@@ -153,10 +149,9 @@ namespace Microsoft.StreamProcessing
 
                                         if (arcinfo.Fence(synctime, currentList.payloads[0], state.register))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = state.register;
-                                            else newReg = arcinfo.Transfer(synctime, currentList.payloads[0], state.register);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, currentList.payloads[0], state.register);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {
@@ -169,10 +164,7 @@ namespace Microsoft.StreamProcessing
                                                     this.batch.hash.col[this.iter] = el_hash;
                                                     this.iter++;
 
-                                                    if (this.iter == Config.DataBatchSize)
-                                                    {
-                                                        FlushContents();
-                                                    }
+                                                    if (this.iter == Config.DataBatchSize) FlushContents();
                                                 }
 
                                                 if (this.hasOutgoingArcs[ns])
@@ -219,59 +211,54 @@ namespace Microsoft.StreamProcessing
                     #region eventListStateMap
                     if (this.eventListStateMap != null)
                     {
-                    var startStateMap = this.eventListStateMap[startState];
-                    if (startStateMap != null)
-                    {
-                        var m = startStateMap.Length;
-                        for (int cnt = 0; cnt < m; cnt++)
+                        var startStateMap = this.eventListStateMap[startState];
+                        if (startStateMap != null)
                         {
-                            var arcinfo = startStateMap[cnt];
-                            if (arcinfo.Fence(synctime, currentList.payloads, this.defaultRegister))
+                            var m = startStateMap.Length;
+                            for (int cnt = 0; cnt < m; cnt++)
                             {
-                                TRegister newReg;
-                                if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                else newReg = arcinfo.Transfer(synctime, currentList.payloads, this.defaultRegister);
-
-                                int ns = arcinfo.toState;
-                                while (true)
+                                var arcinfo = startStateMap[cnt];
+                                if (arcinfo.Fence(synctime, currentList.payloads, this.defaultRegister))
                                 {
-                                    if (this.isFinal[ns])
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, currentList.payloads, this.defaultRegister);
+                                    int ns = arcinfo.toState;
+                                    while (true)
                                     {
-                                        this.batch.vsync.col[this.iter] = synctime;
-                                        this.batch.vother.col[this.iter] = synctime + this.MaxDuration;
-                                        this.batch[this.iter] = newReg;
-                                        this.batch.key.col[this.iter] = currentList.key;
-                                        this.batch.hash.col[this.iter] = el_hash;
-                                        this.iter++;
-
-                                        if (this.iter == Config.DataBatchSize)
+                                        if (this.isFinal[ns])
                                         {
-                                            FlushContents();
+                                            this.batch.vsync.col[this.iter] = synctime;
+                                            this.batch.vother.col[this.iter] = synctime + this.MaxDuration;
+                                            this.batch[this.iter] = newReg;
+                                            this.batch.key.col[this.iter] = currentList.key;
+                                            this.batch.hash.col[this.iter] = el_hash;
+                                            this.iter++;
+
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
-                                    }
-                                    if (this.hasOutgoingArcs[ns])
-                                    {
-                                        int index = this.activeStates.Insert(el_hash);
-                                        this.activeStates.Values[index].key = currentList.key;
-                                        this.activeStates.Values[index].state = ns;
-                                        this.activeStates.Values[index].register = newReg;
-                                        this.activeStates.Values[index].PatternStartTimestamp = synctime;
-
-
-                                        // Add epsilon arc destinations to stack
-                                        if (this.epsilonStateMap == null) break;
-                                        if (this.epsilonStateMap[ns] != null)
+                                        if (this.hasOutgoingArcs[ns])
                                         {
-                                            for (int cnt2 = 0; cnt2 < this.epsilonStateMap[ns].Length; cnt2++) this.stack.Push(this.epsilonStateMap[ns][cnt2]);
+                                            int index = this.activeStates.Insert(el_hash);
+                                            this.activeStates.Values[index].key = currentList.key;
+                                            this.activeStates.Values[index].state = ns;
+                                            this.activeStates.Values[index].register = newReg;
+                                            this.activeStates.Values[index].PatternStartTimestamp = synctime;
+
+                                            // Add epsilon arc destinations to stack
+                                            if (this.epsilonStateMap == null) break;
+                                            if (this.epsilonStateMap[ns] != null)
+                                            {
+                                                for (int cnt2 = 0; cnt2 < this.epsilonStateMap[ns].Length; cnt2++) this.stack.Push(this.epsilonStateMap[ns][cnt2]);
+                                            }
                                         }
+                                        if (this.stack.Count == 0) break;
+                                        ns = this.stack.Pop();
                                     }
-                                    if (this.stack.Count == 0) break;
-                                    ns = this.stack.Pop();
+                                    if (this.IsDeterministic) break; // We are guaranteed to have only one successful transition
                                 }
-                                if (this.IsDeterministic) break; // We are guaranteed to have only one successful transition
                             }
                         }
-                    }
                     }
                     #endregion
 
@@ -288,10 +275,9 @@ namespace Microsoft.StreamProcessing
                                 var arcinfo = startStateMap[cnt];
                                 if (arcinfo.Fence(synctime, currentList.payloads[0], this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, currentList.payloads[0], this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, currentList.payloads[0], this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -304,10 +290,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = el_hash;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {
@@ -442,8 +425,6 @@ namespace Microsoft.StreamProcessing
         }
 
         protected override void UpdatePointers()
-        {
-            this.activeFindTraverser = new FastMap<GroupedActiveState<TKey, TRegister>>.FindTraverser(this.activeStates);
-        }
+            => this.activeFindTraverser = new FastMap<GroupedActiveState<TKey, TRegister>>.FindTraverser(this.activeStates);
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_MultiEvent.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_MultiEvent.cs
@@ -30,9 +30,7 @@ namespace Microsoft.StreamProcessing
 
         [Obsolete("Used only by serialization. Do not call directly.")]
         public CompiledPartitionedAfaPipe_MultiEvent()
-        {
-            this.getPartitionKey = GetPartitionExtractor<TPartitionKey, TKey>();
-        }
+            => this.getPartitionKey = GetPartitionExtractor<TPartitionKey, TKey>();
 
         public CompiledPartitionedAfaPipe_MultiEvent(Streamable<TKey, TRegister> stream, IStreamObserver<TKey, TRegister> observer, object afa, long maxDuration)
             : base(stream, observer, afa, maxDuration, false)
@@ -275,8 +273,6 @@ namespace Microsoft.StreamProcessing
         }
 
         protected override void UpdatePointers()
-        {
-            this.activeFindTraverser = new FastMap<GroupedActiveStateAccumulator<TKey, TPayload, TRegister, TAccumulator>>.FindTraverser(this.activeStates);
-        }
+            => this.activeFindTraverser = new FastMap<GroupedActiveStateAccumulator<TKey, TPayload, TRegister, TAccumulator>>.FindTraverser(this.activeStates);
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_MultiEventList.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_MultiEventList.cs
@@ -27,13 +27,11 @@ namespace Microsoft.StreamProcessing
         private FastMap<GroupedActiveState<TKey, TRegister>>.FindTraverser activeFindTraverser;
 
         // Field instead of local variable to avoid re-initializing it
-        private Stack<int> stack = new Stack<int>();
+        private readonly Stack<int> stack = new Stack<int>();
 
         [Obsolete("Used only by serialization. Do not call directly.")]
         public CompiledPartitionedAfaPipe_MultiEventList()
-        {
-            this.getPartitionKey = GetPartitionExtractor<TPartitionKey, TKey>();
-        }
+            => this.getPartitionKey = GetPartitionExtractor<TPartitionKey, TKey>();
 
         public CompiledPartitionedAfaPipe_MultiEventList(Streamable<TKey, TRegister> stream, IStreamObserver<TKey, TRegister> observer, object afa, long maxDuration)
             : base(stream, observer, afa, maxDuration, false)
@@ -87,7 +85,7 @@ namespace Microsoft.StreamProcessing
                                     {
                                         var arcinfo = currentStateMap[cnt];
 
-                                        TAccumulator acc = arcinfo.Initialize(synctime, state.register);
+                                        var acc = arcinfo.Initialize(synctime, state.register);
                                         for (int i = 0; i < currentList.payloads.Count; i++)
                                         {
                                             var payload = currentList.payloads[i];
@@ -97,10 +95,9 @@ namespace Microsoft.StreamProcessing
 
                                         if (arcinfo.Fence(synctime, acc, state.register))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = state.register;
-                                            else newReg = arcinfo.Transfer(synctime, acc, state.register);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, acc, state.register);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {
@@ -113,10 +110,7 @@ namespace Microsoft.StreamProcessing
                                                     this.batch.hash.col[this.iter] = el_hash;
                                                     this.iter++;
 
-                                                    if (this.iter == Config.DataBatchSize)
-                                                    {
-                                                        FlushContents();
-                                                    }
+                                                    if (this.iter == Config.DataBatchSize) FlushContents();
                                                 }
 
                                                 if (this.hasOutgoingArcs[ns])
@@ -163,10 +157,9 @@ namespace Microsoft.StreamProcessing
 
                                         if (arcinfo.Fence(synctime, item, state.register))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = state.register;
-                                            else newReg = arcinfo.Transfer(synctime, item, state.register);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, item, state.register);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {
@@ -179,10 +172,7 @@ namespace Microsoft.StreamProcessing
                                                     this.batch.hash.col[this.iter] = el_hash;
                                                     this.iter++;
 
-                                                    if (this.iter == Config.DataBatchSize)
-                                                    {
-                                                        FlushContents();
-                                                    }
+                                                    if (this.iter == Config.DataBatchSize) FlushContents();
                                                 }
 
                                                 if (this.hasOutgoingArcs[ns])
@@ -237,10 +227,9 @@ namespace Microsoft.StreamProcessing
 
                                         if (arcinfo.Fence(synctime, payloadList, state.register))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = state.register;
-                                            else newReg = arcinfo.Transfer(synctime, payloadList, state.register);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? state.register
+                                                : arcinfo.Transfer(synctime, payloadList, state.register);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {
@@ -253,10 +242,7 @@ namespace Microsoft.StreamProcessing
                                                     this.batch.hash.col[this.iter] = el_hash;
                                                     this.iter++;
 
-                                                    if (this.iter == Config.DataBatchSize)
-                                                    {
-                                                        FlushContents();
-                                                    }
+                                                    if (this.iter == Config.DataBatchSize) FlushContents();
                                                 }
 
                                                 if (this.hasOutgoingArcs[ns])
@@ -311,7 +297,7 @@ namespace Microsoft.StreamProcessing
                             {
                                 var arcinfo = startStateMap[cnt];
 
-                                TAccumulator acc = arcinfo.Initialize(synctime, this.defaultRegister);
+                                var acc = arcinfo.Initialize(synctime, this.defaultRegister);
                                 for (int i = 0; i < currentList.payloads.Count; i++)
                                 {
                                     var payload = currentList.payloads[i];
@@ -321,10 +307,9 @@ namespace Microsoft.StreamProcessing
 
                                 if (arcinfo.Fence(synctime, acc, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, acc, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, acc, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -380,10 +365,9 @@ namespace Microsoft.StreamProcessing
 
                                 if (arcinfo.Fence(synctime, item, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, item, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, item, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -396,10 +380,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = el_hash;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {
@@ -450,10 +431,9 @@ namespace Microsoft.StreamProcessing
 
                                 if (arcinfo.Fence(synctime, payloadList, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, payloadList, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, payloadList, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -466,10 +446,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = el_hash;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {
@@ -478,7 +455,6 @@ namespace Microsoft.StreamProcessing
                                             this.activeStates.Values[index].state = ns;
                                             this.activeStates.Values[index].register = newReg;
                                             this.activeStates.Values[index].PatternStartTimestamp = synctime;
-
 
                                             // Add epsilon arc destinations to stack
                                             if (this.epsilonStateMap == null) break;
@@ -611,8 +587,6 @@ namespace Microsoft.StreamProcessing
         }
 
         protected override void UpdatePointers()
-        {
-            this.activeFindTraverser = new FastMap<GroupedActiveState<TKey, TRegister>>.FindTraverser(this.activeStates);
-        }
+            => this.activeFindTraverser = new FastMap<GroupedActiveState<TKey, TRegister>>.FindTraverser(this.activeStates);
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_SingleEvent.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_SingleEvent.cs
@@ -30,9 +30,7 @@ namespace Microsoft.StreamProcessing
 
         [Obsolete("Used only by serialization. Do not call directly.")]
         public CompiledPartitionedAfaPipe_SingleEvent()
-        {
-            this.getPartitionKey = GetPartitionExtractor<TPartitionKey, TKey>();
-        }
+            => this.getPartitionKey = GetPartitionExtractor<TPartitionKey, TKey>();
 
         public CompiledPartitionedAfaPipe_SingleEvent(AfaStreamable<TKey, TPayload, TRegister, TAccumulator> stream, IStreamObserver<TKey, TRegister> observer, object afa, long maxDuration)
             : base(stream, observer, afa, maxDuration, false)
@@ -184,10 +182,9 @@ namespace Microsoft.StreamProcessing
 
                                                 if (arcinfo.Fence(synctime, batch[i], state.register))
                                                 {
-                                                    TRegister newReg;
-                                                    if (arcinfo.Transfer == null) newReg = state.register;
-                                                    else newReg = arcinfo.Transfer(synctime, batch[i], state.register);
-
+                                                    var newReg = arcinfo.Transfer == null
+                                                        ? state.register
+                                                        : arcinfo.Transfer(synctime, batch[i], state.register);
                                                     int ns = arcinfo.toState;
                                                     while (true)
                                                     {
@@ -270,10 +267,9 @@ namespace Microsoft.StreamProcessing
                                         var arcinfo = startStateMap[cnt];
                                         if (arcinfo.Fence(synctime, batch[i], this.defaultRegister))
                                         {
-                                            TRegister newReg;
-                                            if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                            else newReg = arcinfo.Transfer(synctime, batch[i], this.defaultRegister);
-
+                                            var newReg = arcinfo.Transfer == null
+                                                ? this.defaultRegister
+                                                : arcinfo.Transfer(synctime, batch[i], this.defaultRegister);
                                             int ns = arcinfo.toState;
                                             while (true)
                                             {
@@ -365,10 +361,7 @@ namespace Microsoft.StreamProcessing
                                                 this.batch.hash.col[this.iter] = hash;
                                                 this.iter++;
 
-                                                if (this.iter == Config.DataBatchSize)
-                                                {
-                                                    FlushContents();
-                                                }
+                                                if (this.iter == Config.DataBatchSize) FlushContents();
                                             }
 
                                             this.tentativeOutput.entries[partitionIndex].value.Clear(); // Clear the tentative output list
@@ -411,10 +404,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = hash;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
 
                                         this.tentativeOutput.entries[partitionIndex].value.Clear(); // Clear the tentative output list
@@ -432,10 +422,7 @@ namespace Microsoft.StreamProcessing
                             this.batch.bitvector.col[this.iter >> 6] |= (1L << (this.iter & 0x3f));
                             this.iter++;
 
-                            if (this.iter == Config.DataBatchSize)
-                            {
-                                FlushContents();
-                            }
+                            if (this.iter == Config.DataBatchSize) FlushContents();
                         }
                     }
                 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledUngroupedAfaPipe_EventList.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledUngroupedAfaPipe_EventList.cs
@@ -75,10 +75,9 @@ namespace Microsoft.StreamProcessing
 
                                     if (arcinfo.Fence(synctime, this.currentList, state.register))
                                     {
-                                        TRegister newReg;
-                                        if (arcinfo.Transfer == null) newReg = state.register;
-                                        else newReg = arcinfo.Transfer(synctime, this.currentList, state.register);
-
+                                        var newReg = arcinfo.Transfer == null
+                                            ? state.register
+                                            : arcinfo.Transfer(synctime, this.currentList, state.register);
                                         int ns = arcinfo.toState;
                                         while (true)
                                         {
@@ -90,10 +89,7 @@ namespace Microsoft.StreamProcessing
                                                 this.batch.hash.col[this.iter] = 0;
                                                 this.iter++;
 
-                                                if (this.iter == Config.DataBatchSize)
-                                                {
-                                                    FlushContents();
-                                                }
+                                                if (this.iter == Config.DataBatchSize) FlushContents();
                                             }
 
                                             if (this.hasOutgoingArcs[ns])
@@ -137,10 +133,9 @@ namespace Microsoft.StreamProcessing
 
                                     if (arcinfo.Fence(synctime, this.currentList[0], state.register))
                                     {
-                                        TRegister newReg;
-                                        if (arcinfo.Transfer == null) newReg = state.register;
-                                        else newReg = arcinfo.Transfer(synctime, this.currentList[0], state.register);
-
+                                        var newReg = arcinfo.Transfer == null
+                                            ? state.register
+                                            : arcinfo.Transfer(synctime, this.currentList[0], state.register);
                                         int ns = arcinfo.toState;
                                         while (true)
                                         {
@@ -152,10 +147,7 @@ namespace Microsoft.StreamProcessing
                                                 this.batch.hash.col[this.iter] = 0;
                                                 this.iter++;
 
-                                                if (this.iter == Config.DataBatchSize)
-                                                {
-                                                    FlushContents();
-                                                }
+                                                if (this.iter == Config.DataBatchSize) FlushContents();
                                             }
 
                                             if (this.hasOutgoingArcs[ns])
@@ -211,10 +203,9 @@ namespace Microsoft.StreamProcessing
                                 var arcinfo = startStateMap[cnt];
                                 if (arcinfo.Fence(synctime, this.currentList, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, this.currentList, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, this.currentList, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -226,10 +217,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = 0;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {
@@ -269,10 +257,9 @@ namespace Microsoft.StreamProcessing
                                 var arcinfo = startStateMap[cnt];
                                 if (arcinfo.Fence(synctime, this.currentList[0], this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, this.currentList[0], this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, this.currentList[0], this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -284,10 +271,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = 0;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {
@@ -295,7 +279,6 @@ namespace Microsoft.StreamProcessing
                                             this.activeStates.Values[index].state = ns;
                                             this.activeStates.Values[index].register = newReg;
                                             this.activeStates.Values[index].PatternStartTimestamp = synctime;
-
 
                                             // Add epsilon arc destinations to stack
                                             if (this.epsilonStateMap == null) break;
@@ -360,8 +343,6 @@ namespace Microsoft.StreamProcessing
         }
 
         protected override void UpdatePointers()
-        {
-            this.activeStatesTraverser = new FastLinkedList<GroupedActiveState<Empty, TRegister>>.ListTraverser(this.activeStates);
-        }
+            => this.activeStatesTraverser = new FastLinkedList<GroupedActiveState<Empty, TRegister>>.ListTraverser(this.activeStates);
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledUngroupedAfaPipe_MultiEventList.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledUngroupedAfaPipe_MultiEventList.cs
@@ -74,7 +74,7 @@ namespace Microsoft.StreamProcessing
                                 {
                                     var arcinfo = currentStateMap[cnt];
 
-                                    TAccumulator acc = arcinfo.Initialize(synctime, state.register);
+                                    var acc = arcinfo.Initialize(synctime, state.register);
                                     for (int i = 0; i < this.currentTimestampEventList.Count; i++)
                                     {
                                         var payload = this.currentTimestampEventList[i];
@@ -84,10 +84,9 @@ namespace Microsoft.StreamProcessing
 
                                     if (arcinfo.Fence(synctime, acc, state.register))
                                     {
-                                        TRegister newReg;
-                                        if (arcinfo.Transfer == null) newReg = state.register;
-                                        else newReg = arcinfo.Transfer(synctime, acc, state.register);
-
+                                        var newReg = arcinfo.Transfer == null
+                                            ? state.register
+                                            : arcinfo.Transfer(synctime, acc, state.register);
                                         int ns = arcinfo.toState;
                                         while (true)
                                         {
@@ -99,10 +98,7 @@ namespace Microsoft.StreamProcessing
                                                 this.batch.hash.col[this.iter] = 0;
                                                 this.iter++;
 
-                                                if (this.iter == Config.DataBatchSize)
-                                                {
-                                                    FlushContents();
-                                                }
+                                                if (this.iter == Config.DataBatchSize) FlushContents();
                                             }
 
                                             if (this.hasOutgoingArcs[ns])
@@ -148,10 +144,9 @@ namespace Microsoft.StreamProcessing
 
                                     if (arcinfo.Fence(synctime, item, state.register))
                                     {
-                                        TRegister newReg;
-                                        if (arcinfo.Transfer == null) newReg = state.register;
-                                        else newReg = arcinfo.Transfer(synctime, item, state.register);
-
+                                        var newReg = arcinfo.Transfer == null
+                                            ? state.register
+                                            : arcinfo.Transfer(synctime, item, state.register);
                                         int ns = arcinfo.toState;
                                         while (true)
                                         {
@@ -163,10 +158,7 @@ namespace Microsoft.StreamProcessing
                                                 this.batch.hash.col[this.iter] = 0;
                                                 this.iter++;
 
-                                                if (this.iter == Config.DataBatchSize)
-                                                {
-                                                    FlushContents();
-                                                }
+                                                if (this.iter == Config.DataBatchSize) FlushContents();
                                             }
 
                                             if (this.hasOutgoingArcs[ns])
@@ -220,10 +212,9 @@ namespace Microsoft.StreamProcessing
 
                                     if (arcinfo.Fence(synctime, payloadList, state.register))
                                     {
-                                        TRegister newReg;
-                                        if (arcinfo.Transfer == null) newReg = state.register;
-                                        else newReg = arcinfo.Transfer(synctime, payloadList, state.register);
-
+                                        var newReg = arcinfo.Transfer == null
+                                            ? state.register
+                                            : arcinfo.Transfer(synctime, payloadList, state.register);
                                         int ns = arcinfo.toState;
                                         while (true)
                                         {
@@ -235,10 +226,7 @@ namespace Microsoft.StreamProcessing
                                                 this.batch.hash.col[this.iter] = 0;
                                                 this.iter++;
 
-                                                if (this.iter == Config.DataBatchSize)
-                                                {
-                                                    FlushContents();
-                                                }
+                                                if (this.iter == Config.DataBatchSize) FlushContents();
                                             }
 
                                             if (this.hasOutgoingArcs[ns])
@@ -293,7 +281,7 @@ namespace Microsoft.StreamProcessing
                             {
                                 var arcinfo = startStateMap[cnt];
 
-                                TAccumulator acc = arcinfo.Initialize(synctime, this.defaultRegister);
+                                var acc = arcinfo.Initialize(synctime, this.defaultRegister);
                                 for (int i = 0; i < this.currentTimestampEventList.Count; i++)
                                 {
                                     var payload = this.currentTimestampEventList[i];
@@ -303,10 +291,9 @@ namespace Microsoft.StreamProcessing
 
                                 if (arcinfo.Fence(synctime, acc, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, acc, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, acc, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -318,10 +305,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = 0;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {
@@ -364,10 +348,9 @@ namespace Microsoft.StreamProcessing
 
                                 if (arcinfo.Fence(synctime, item, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, item, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, item, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -379,10 +362,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = 0;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {
@@ -432,10 +412,9 @@ namespace Microsoft.StreamProcessing
 
                                 if (arcinfo.Fence(synctime, payloadList, this.defaultRegister))
                                 {
-                                    TRegister newReg;
-                                    if (arcinfo.Transfer == null) newReg = this.defaultRegister;
-                                    else newReg = arcinfo.Transfer(synctime, payloadList, this.defaultRegister);
-
+                                    var newReg = arcinfo.Transfer == null
+                                        ? this.defaultRegister
+                                        : arcinfo.Transfer(synctime, payloadList, this.defaultRegister);
                                     int ns = arcinfo.toState;
                                     while (true)
                                     {
@@ -447,10 +426,7 @@ namespace Microsoft.StreamProcessing
                                             this.batch.hash.col[this.iter] = 0;
                                             this.iter++;
 
-                                            if (this.iter == Config.DataBatchSize)
-                                            {
-                                                FlushContents();
-                                            }
+                                            if (this.iter == Config.DataBatchSize) FlushContents();
                                         }
                                         if (this.hasOutgoingArcs[ns])
                                         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/Regex.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/Regex.cs
@@ -548,9 +548,7 @@ namespace Microsoft.StreamProcessing
         /// <param name="patterns">Any remaining patterns to be concatenated, in order</param>
         /// <returns>A pattern whose first transition is the one just created</returns>
         public static Afa<TInput, TRegister, TAccumulator> Concat<TInput, TRegister, TAccumulator>(Afa<TInput, TRegister, TAccumulator> pattern1, Afa<TInput, TRegister, TAccumulator> pattern2, params Afa<TInput, TRegister, TAccumulator>[] patterns)
-        {
-            return ConcatWorker(false, pattern1, pattern2, patterns);
-        }
+            => ConcatWorker(false, pattern1, pattern2, patterns);
 
         /// <summary>
         /// Creates a new pattern resulting from the concatenation of other patterns, but where each individual pattern may result in a final state
@@ -563,13 +561,10 @@ namespace Microsoft.StreamProcessing
         /// <param name="patterns">Any remaining patterns to be concatenated, in order</param>
         /// <returns>A pattern whose first transition is the one just created</returns>
         public static Afa<TInput, TRegister, TAccumulator> OrConcat<TInput, TRegister, TAccumulator>(Afa<TInput, TRegister, TAccumulator> pattern1, Afa<TInput, TRegister, TAccumulator> pattern2, params Afa<TInput, TRegister, TAccumulator>[] patterns)
-        {
-            return ConcatWorker(true, pattern1, pattern2, patterns);
-        }
+            => ConcatWorker(true, pattern1, pattern2, patterns);
 
         private static Afa<TInput, TRegister, TAccumulator> ConcatWorker<TInput, TRegister, TAccumulator>(bool isOr, Afa<TInput, TRegister, TAccumulator> pattern1, Afa<TInput, TRegister, TAccumulator> pattern2, params Afa<TInput, TRegister, TAccumulator>[] patterns)
         {
-
             var allPatterns = new Afa<TInput, TRegister, TAccumulator>[patterns.Length + 2];
             allPatterns[0] = pattern1;
             allPatterns[1] = pattern2;
@@ -581,7 +576,6 @@ namespace Microsoft.StreamProcessing
 
             for (int i = 1; i < allPatterns.Length; i++)
             {
-
                 var nextPattern = allPatterns[i];
 
                 var newFinal = result.MaxState + 1;
@@ -589,7 +583,7 @@ namespace Microsoft.StreamProcessing
                 var epsilonArcAdded = false;
                 foreach (var finalState in result.finalStates)
                 {
-                    if (result.transitionInfo.TryGetValue(finalState, out Dictionary<int, Arc<TInput, TRegister>> outgoingEdges))
+                    if (result.transitionInfo.TryGetValue(finalState, out var outgoingEdges))
                     {
                         result.AddArc(finalState, newFinal, new EpsilonArc<TInput, TRegister> { });
                         if (!epsilonArcAdded)
@@ -618,15 +612,13 @@ namespace Microsoft.StreamProcessing
                             int from = kvp1.Key;
                             int to = kvp2.Key;
 
-                            if (from == nextPattern.StartState)
-                                from = oldFinal;
-                            else
-                                from = from + oldMax;
+                            from = from == nextPattern.StartState
+                                ? oldFinal
+                                : from + oldMax;
 
-                            if (to == nextPattern.StartState)
-                                to = oldFinal;
-                            else
-                                to = to + oldMax;
+                            to = to == nextPattern.StartState
+                                ? oldFinal
+                                : to + oldMax;
 
                             result.AddArc(from, to, kvp2.Value);
 
@@ -750,9 +742,7 @@ namespace Microsoft.StreamProcessing
         /// <param name="pattern">The pattern to iterate</param>
         /// <returns>A pattern whose first transition is the one just created</returns>
         public static Afa<TInput, TRegister, TAccumulator> KleenePlus<TInput, TRegister, TAccumulator>(Afa<TInput, TRegister, TAccumulator> pattern)
-        {
-            return Concat(pattern, KleeneStar(pattern));
-        }
+            => Concat(pattern, KleeneStar(pattern));
 
         /// <summary>
         /// Creates a new pattern resulting from zero or one instances of the given pattern

--- a/Sources/Core/Microsoft.StreamProcessing/StreamableAPI/AfaExtensions.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/StreamableAPI/AfaExtensions.cs
@@ -166,9 +166,7 @@ namespace Microsoft.StreamProcessing
         /// <param name="source">Input stream over which to define a pattern</param>
         /// <returns>The beginning of a builder from which a pattern may be defined</returns>
         public static IAbstractPattern<TKey, TPayload, Empty, bool> DefinePattern<TKey, TPayload>(this IStreamable<TKey, TPayload> source)
-        {
-            return new PatternMatcher<TKey, TPayload, Empty, bool>(source, null);
-        }
+            => new PatternMatcher<TKey, TPayload, Empty, bool>(source);
 
         /// <summary>
         /// Define a pattern against which data in the input stream may be matched
@@ -183,9 +181,7 @@ namespace Microsoft.StreamProcessing
         /// <returns>The beginning of a builder from which a pattern may be defined</returns>
         public static IAbstractPattern<TKey, TPayload, TRegister, TAccumulator> DefinePattern<TKey, TPayload, TRegister, TAccumulator>(
             this IStreamable<TKey, TPayload> source, TRegister defaultRegister, TAccumulator defaultAccumulator)
-        {
-            return new PatternMatcher<TKey, TPayload, TRegister, TAccumulator>(source, null);
-        }
+            => new PatternMatcher<TKey, TPayload, TRegister, TAccumulator>(source, null, defaultRegister);
         #endregion
 
         #region Macro extensions for pattern matching
@@ -224,9 +220,7 @@ namespace Microsoft.StreamProcessing
             Expression<Func<TAccumulator>> accumulatorInitialization,
             Expression<Func<TAccumulator, bool>> accumulatorBoolField,
             Expression<Func<long, TPayload, TRegister, bool>> fence)
-        {
-            return CreateMultiElementFunctions(source, accumulatorInitialization, accumulatorBoolField, fence, false, b => b);
-        }
+            => CreateMultiElementFunctions(source, accumulatorInitialization, accumulatorBoolField, fence, false, b => b);
 
         /// <summary>
         /// Add to the current pattern a new pattern symbol that matches all elements
@@ -266,9 +260,7 @@ namespace Microsoft.StreamProcessing
             Expression<Func<TAccumulator>> accumulatorInitialization,
             Expression<Func<TAccumulator, bool>> accumulatorBoolField,
             Expression<Func<long, TPayload, TRegister, bool>> fence)
-        {
-            return CreateMultiElementFunctions(source, accumulatorInitialization, accumulatorBoolField, fence, true, b => !b);
-        }
+            => CreateMultiElementFunctions(source, accumulatorInitialization, accumulatorBoolField, fence, true, b => !b);
 
         private static IPattern<TKey, TPayload, TRegister, TAccumulator> CreateMultiElementFunctions<TKey, TPayload, TRegister, TAccumulator>(IAbstractPatternRoot<TKey, TPayload, TRegister, TAccumulator> source, Expression<Func<TAccumulator>> accumulatorInitialization, Expression<Func<TAccumulator, bool>> accumulatorboolField, Expression<Func<long, TPayload, TRegister, bool>> fence, bool initialValueForBooleanField, Expression<Func<bool, bool>> shortCircuitCondition)
         {

--- a/Sources/Test/SimpleTesting/AfaTests.cs
+++ b/Sources/Test/SimpleTesting/AfaTests.cs
@@ -17,20 +17,15 @@ namespace SimpleTesting
     {
         public FList()
             : base()
-        {
-
-        }
+        { }
 
         public FList(int capacity)
             : base(capacity)
-        {
-
-        }
+        { }
 
         public FList(IEnumerable<T> collection)
             : base(collection)
-        {
-        }
+        { }
 
         public new FList<T> Add(T t)
         {
@@ -38,10 +33,7 @@ namespace SimpleTesting
             return this;
         }
 
-        public FList<T> Clone()
-        {
-            return new FList<T>(this);
-        }
+        public FList<T> Clone() => new FList<T>(this);
 
         public new FList<T> Clear()
         {
@@ -344,6 +336,7 @@ namespace SimpleTesting
             Assert.IsTrue(result.SequenceEqual(expected));
 
         }
+
         public static void AfaDefinePattern02()
         {
             var source1 = new StreamEvent<AfaPayload>[] {
@@ -376,6 +369,7 @@ namespace SimpleTesting
             Assert.IsTrue(result.SequenceEqual(expected));
 
         }
+
         public static void AfaDefinePattern03()
         {
             var source1 = new StreamEvent<AfaPayload>[] {
@@ -390,7 +384,7 @@ namespace SimpleTesting
             var result =
                 source1
                 .DefinePattern()
-                .SetRegister(0) // or .SetRegister<int>()
+                .SetRegister(10) // or .SetRegister<int>()
                 .SingleElement(e => e.Field1 == "A", (l, p, i) => i + p.Field2)
                 .SingleElement(e => e.Field1 == "C", (l, p, i) => i + p.Field2)
                 .Detect()
@@ -401,7 +395,7 @@ namespace SimpleTesting
                 ;
 
             var expected = new StreamEvent<int>[] {
-                StreamEvent.CreateInterval(110, 1100, 7),
+                StreamEvent.CreateInterval(110, 1100, 17),
             };
             Assert.IsTrue(result.SequenceEqual(expected));
 
@@ -465,6 +459,7 @@ namespace SimpleTesting
             };
             Assert.IsTrue(result.SequenceEqual(expected));
         }
+
         public static Register CreateOrAddToRegister(Payload2 p, Register r, bool isNegativeMatch)
         {
             var ret = new Register();
@@ -480,6 +475,7 @@ namespace SimpleTesting
             }
             return ret;
         }
+
         public static void DAfa01()
         {
            // Config.CodegenOptions.BreakIntoCodeGen = Config.CodegenOptions.DebugFlags.Operators;
@@ -506,6 +502,7 @@ namespace SimpleTesting
             Assert.IsTrue(registers.Count == 1 && registers[0] == null); // really just want to test that code gen didn't fail.
         }
     }
+
     [TestClass]
     public class AfaTestsWithoutCodegen : TestWithConfigSettingsAndMemoryLeakDetection
     {
@@ -536,6 +533,9 @@ namespace SimpleTesting
 
         [TestMethod, TestCategory("Gated")]
         public void AfaDefinePatternWithoutCodegen02() => AfaTests.AfaDefinePattern02();
+
+        [TestMethod, TestCategory("Gated")]
+        public void AfaDefinePatternWithoutCodegen03() => AfaTests.AfaDefinePattern03();
 
         [TestMethod, TestCategory("Gated")]
         public void DAfaWithoutCodegen01() => AfaTests.DAfa01();
@@ -578,6 +578,9 @@ namespace SimpleTesting
 
         [TestMethod, TestCategory("Gated")]
         public void AfaDefinePatternWithCodegen02() => AfaTests.AfaDefinePattern02();
+
+        [TestMethod, TestCategory("Gated")]
+        public void AfaDefinePatternWithCodegen03() => AfaTests.AfaDefinePattern03();
 
         [TestMethod, TestCategory("Gated")]
         public void DAfaWithCodegen01() => AfaTests.DAfa01();


### PR DESCRIPTION
The current code has an oversight, where the default register in an AFA never makes it from the PatternMatcher but only having its type inferred and then the value ignored.