### PR TITLE
Fixing partitioned out of order bug for a few binary partitioned operators

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/PartitionedClipJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/PartitionedClipJoinPipe.cs
@@ -272,7 +272,14 @@ namespace Microsoft.StreamProcessing
                         leftEntry = leftWorking.Peek();
                         partition.nextLeftTime = leftEntry.Sync;
                         partition.nextRightTime = Math.Max(partition.nextRightTime, this.lastRightCTI);
-                        if (partition.nextLeftTime > partition.nextRightTime) break;
+                        if (partition.nextLeftTime > partition.nextRightTime)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, right), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextRightTime)
+                                UpdateTime(partition, partition.nextRightTime);
+                            break;
+                        }
 
                         UpdateTime(partition, partition.nextLeftTime);
 
@@ -303,7 +310,14 @@ namespace Microsoft.StreamProcessing
                         rightEntry = rightWorking.Peek();
                         partition.nextRightTime = rightEntry.Sync;
                         partition.nextLeftTime = Math.Max(partition.nextLeftTime, this.lastLeftCTI);
-                        if (partition.nextLeftTime < partition.nextRightTime) break;
+                        if (partition.nextLeftTime < partition.nextRightTime)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, left), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextLeftTime)
+                                UpdateTime(partition, partition.nextLeftTime);
+                            break;
+                        }
 
                         UpdateTime(partition, partition.nextRightTime);
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipe.cs
@@ -334,7 +334,14 @@ namespace Microsoft.StreamProcessing
                         leftEntry = leftWorking.Peek();
                         UpdateNextLeftTime(partition, leftEntry.Sync);
                         partition.nextRightTime = Math.Max(partition.nextRightTime, this.lastRightCTI);
-                        if (partition.nextLeftTime > partition.nextRightTime) break;
+                        if (partition.nextLeftTime > partition.nextRightTime)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, right), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextRightTime)
+                                UpdateTime(partition, partition.nextRightTime);
+                            break;
+                        }
 
                         UpdateTime(partition, partition.nextLeftTime);
 
@@ -367,7 +374,14 @@ namespace Microsoft.StreamProcessing
                         rightEntry = rightWorking.Peek();
                         UpdateNextRightTime(partition, rightEntry.Sync);
                         partition.nextLeftTime = Math.Max(partition.nextLeftTime, this.lastLeftCTI);
-                        if (partition.nextLeftTime < partition.nextRightTime) break;
+                        if (partition.nextLeftTime < partition.nextRightTime)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, left), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextLeftTime)
+                                UpdateTime(partition, partition.nextLeftTime);
+                            break;
+                        }
 
                         UpdateTime(partition, partition.nextRightTime);
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeCompound.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeCompound.cs
@@ -332,7 +332,14 @@ namespace Microsoft.StreamProcessing
                         leftEntry = leftWorking.Peek();
                         UpdateNextLeftTime(partition, leftEntry.Sync);
                         partition.nextRightTime = Math.Max(partition.nextRightTime, this.lastRightCTI);
-                        if (partition.nextLeftTime > partition.nextRightTime) break;
+                        if (partition.nextLeftTime > partition.nextRightTime)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, right), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextRightTime)
+                                UpdateTime(partition, partition.nextRightTime);
+                            break;
+                        }
 
                         UpdateTime(partition, partition.nextLeftTime);
 
@@ -366,7 +373,14 @@ namespace Microsoft.StreamProcessing
                         rightEntry = rightWorking.Peek();
                         UpdateNextRightTime(partition, rightEntry.Sync);
                         partition.nextLeftTime = Math.Max(partition.nextLeftTime, this.lastLeftCTI);
-                        if (partition.nextLeftTime < partition.nextRightTime) break;
+                        if (partition.nextLeftTime < partition.nextRightTime)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, left), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextLeftTime)
+                                UpdateTime(partition, partition.nextLeftTime);
+                            break;
+                        }
 
                         UpdateTime(partition, partition.nextRightTime);
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeSimple.cs
@@ -320,7 +320,14 @@ namespace Microsoft.StreamProcessing
                         leftEntry = leftWorking.Peek();
                         UpdateNextLeftTime(partition, leftEntry.Sync);
                         partition.nextRightTime = Math.Max(partition.nextRightTime, this.lastRightCTI);
-                        if (partition.nextLeftTime > partition.nextRightTime) break;
+                        if (partition.nextLeftTime > partition.nextRightTime)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, right), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextRightTime)
+                                UpdateTime(partition, partition.nextRightTime);
+                            break;
+                        }
 
                         UpdateTime(partition, partition.nextLeftTime);
 
@@ -350,7 +357,14 @@ namespace Microsoft.StreamProcessing
                         rightEntry = rightWorking.Peek();
                         UpdateNextRightTime(partition, rightEntry.Sync);
                         partition.nextLeftTime = Math.Max(partition.nextLeftTime, this.lastLeftCTI);
-                        if (partition.nextLeftTime < partition.nextRightTime) break;
+                        if (partition.nextLeftTime < partition.nextRightTime)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, left), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextLeftTime)
+                                UpdateTime(partition, partition.nextLeftTime);
+                            break;
+                        }
 
                         UpdateTime(partition, partition.nextRightTime);
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/LeftAntiSemiJoin/PartitionedLeftAntiSemiJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/LeftAntiSemiJoin/PartitionedLeftAntiSemiJoinPipe.cs
@@ -289,7 +289,14 @@ namespace Microsoft.StreamProcessing
                     {
                         partition.nextLeftTime = leftEntry.Sync;
                         partition.nextRightTime = Math.Max(partition.nextRightTime, this.lastRightCTI);
-                        if (leftEntry.Sync > partition.nextRightTime) break;
+                        if (leftEntry.Sync > partition.nextRightTime)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, right), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextRightTime)
+                                UpdateTime(partition, partition.nextRightTime);
+                            break;
+                        }
 
                         UpdateTime(partition, leftEntry.Sync);
 
@@ -319,7 +326,14 @@ namespace Microsoft.StreamProcessing
                     {
                         partition.nextRightTime = rightEntry.Sync;
                         partition.nextLeftTime = Math.Max(partition.nextLeftTime, this.lastLeftCTI);
-                        if (partition.nextLeftTime < rightEntry.Sync) break;
+                        if (partition.nextLeftTime < rightEntry.Sync)
+                        {
+                            // If we have not yet reached the lesser of the two sides (in this case, left), and we don't
+                            // have input from that side, reach that time now. This can happen with low watermarks.
+                            if (partition.currTime < partition.nextLeftTime)
+                                UpdateTime(partition, partition.nextLeftTime);
+                            break;
+                        }
 
                         UpdateTime(partition, rightEntry.Sync);
 


### PR DESCRIPTION
Some partitioned binary operators could emit a low watermark before emitting all data events before that point. The conditions for this happening:

one side, say right for this example, has a batch that ends in a low watermark
while processing the other (left) side, the pipe reaches a point where it has run out of data from the right side, but the left side is greater than the next right time (which is inclusive of the low watermark time).
at least one partition has not yet processed data up to the low watermark time (e.g., due to an absence of events leading up to the low watermark time), but has data events waiting to be processed before that low watermark time (e.g., in LASJ, waiting to see if the events from the left match events on the right).
In this case, these operators output the low watermark without processing time up to the low watermark timestamp. Then when it receives future data past the low watermark time, it processes the buffered input before the low watermark timestamp, which then leads to the operator outputting data before the low watermark timestamp that was already output.
The fix is to call UpdateTime to reach the low watermark time before emitting the low watermark when these conditions are met.