### PR TITLE
Fix shard issue

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SprayGroupImport/SprayGroupImportPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SprayGroupImport/SprayGroupImportPipe.cs
@@ -114,7 +114,7 @@ namespace Microsoft.StreamProcessing
                     else
                     {
                         this.pool.Get(out StreamMessage<TKey, TSpray> broadcastClone);
-                        broadcastClone.CloneFromNoPayload(broadcastMaster);
+                        broadcastClone.CloneFrom(broadcastMaster);
                         this.Observers[i].OnNext(broadcastClone);
                     }
                 }


### PR DESCRIPTION
We attempt to broadcast a batch to all shards, but we are calling CloneFromNoPayload instead of clone, leading to a batch with no payload. 