### PR TITLE
Fixing MinTimestamp/MaxTimestamp for punctuations

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Collections/StreamMessage.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Collections/StreamMessage.cs
@@ -1094,13 +1094,13 @@ namespace Microsoft.StreamProcessing
                 else
                 {
                     // Find the first element with non-filtered-out row
-                    int curr = 0;
-                    while (curr < this.Count && (this.bitvector.col[curr >> 6] & (1L << (curr & 0x3f))) != 0)
+                    int cur = 0;
+                    while (cur < this.Count && ((this.bitvector.col[cur >> 6] & (1L << (cur & 0x3f))) != 0) && this.vother.col[cur] >= 0)
                     {
-                        curr++;
+                        cur++;
                     }
 
-                    return curr == this.Count ? StreamEvent.MinSyncTime : this.vsync.col[curr];
+                    return cur == this.Count ? StreamEvent.MinSyncTime : this.vsync.col[cur];
                 }
             }
         }
@@ -1133,13 +1133,13 @@ namespace Microsoft.StreamProcessing
                 else
                 {
                     // Find the last element with non-filtered-out row
-                    int curr = this.Count - 1;
-                    while (curr >= 0 && (this.bitvector.col[curr >> 6] & (1L << (curr & 0x3f))) != 0)
+                    int cur = this.Count - 1;
+                    while (cur >= 0 && ((this.bitvector.col[cur >> 6] & (1L << (cur & 0x3f))) != 0) && this.vother.col[cur] >= 0)
                     {
-                        curr--;
+                        cur--;
                     }
 
-                    return curr < 0 ? StreamEvent.MaxSyncTime : this.vsync.col[curr];
+                    return cur < 0 ? StreamEvent.MaxSyncTime : this.vsync.col[cur];
                 }
             }
         }


### PR DESCRIPTION
Currently, StreamMessage.MinTimestamp/MaxTimestamp does not consider punctuations for non-partitioned streams (partitioned streams are already correct). This is particularly incorrect for single-punctuation batches, where MinTimestamp returns 0. The fix is to consider punctuations in the timestamp calculation.