### PR TITLE
Fixing an incorrect assumption about BinaryStreamable.Initialize()

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/EquiJoinStreamable.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/EquiJoinStreamable.cs
@@ -35,7 +35,7 @@ namespace Microsoft.StreamProcessing
                 this.errorMessages = $"The left input payload type, '{typeof(TLeft).FullName}', to Equijoin does not implement the interface {nameof(IEqualityComparerExpression<TLeft>)}. This interface is needed for code generation of this operator for columnar mode. Furthermore, the equality expression in the interface can only refer to input variables if used in field or property references.";
                 if (Config.CodegenOptions.DontFallBackToRowBasedExecution)
                     throw new StreamProcessingException(this.errorMessages);
-                else this.Left = this.Left.ColumnToRow();
+                this.Left = this.Left.ColumnToRow();
             }
             // This operator uses the equality method on payloads
             if (right.Properties.IsColumnar && !right.Properties.IsStartEdgeOnly && !right.Properties.PayloadEqualityComparer.CanUsePayloadEquality())
@@ -43,7 +43,7 @@ namespace Microsoft.StreamProcessing
                 this.errorMessages = $"The right input payload type, '{typeof(TRight).FullName}', to Equijoin does not implement the interface {nameof(IEqualityComparerExpression<TRight>)}. This interface is needed for code generation of this operator for columnar mode. Furthermore, the equality expression in the interface can only refer to input variables if used in field or property references.";
                 if (Config.CodegenOptions.DontFallBackToRowBasedExecution)
                     throw new StreamProcessingException(this.errorMessages);
-                else this.Right = this.Right.ColumnToRow();
+                this.Right = this.Right.ColumnToRow();
             }
 
             if (left.Properties.IsStartEdgeOnly && right.Properties.IsStartEdgeOnly)

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/LeftAntiSemiJoin/LeftAntiSemiJoinStreamable.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/LeftAntiSemiJoin/LeftAntiSemiJoinStreamable.cs
@@ -30,7 +30,7 @@ namespace Microsoft.StreamProcessing
                 this.errorMessages = $"The payload type, '{typeof(TLeft).FullName}', to Left Antisemijoin does not implement the interface {nameof(IEqualityComparerExpression<TLeft>)}. This interface is needed for code generation of this operator for columnar mode. Furthermore, the equality expression in the interface can only refer to input variables if used in field or property references.";
                 if (Config.CodegenOptions.DontFallBackToRowBasedExecution)
                     throw new StreamProcessingException(this.errorMessages);
-                else this.Left = this.Left.ColumnToRow();
+                this.Left = this.Left.ColumnToRow();
             }
 
             Initialize();

--- a/Sources/Core/Microsoft.StreamProcessing/Streamables/BinaryStreamable.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Streamables/BinaryStreamable.cs
@@ -50,10 +50,12 @@ namespace Microsoft.StreamProcessing
             else if (this.Left.Properties.IsColumnar)
             {
                 this.Left = this.Left.ColumnToRow();
+                this.properties = this.properties.ToRowBased();
             }
             else if (this.Right.Properties.IsColumnar)
             {
                 this.Right = this.Right.ColumnToRow();
+                this.properties = this.properties.ToRowBased();
             }
         }
 


### PR DESCRIPTION
Missed an assumption in the previous change where simply setting one input of a binary operation does not recompute the output properties.