### PR TITLE
Fixing bug where partitions are cleaned up too aggressively

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/CacheUtilities/StreamableIO.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/CacheUtilities/StreamableIO.cs
@@ -42,7 +42,7 @@ namespace Microsoft.StreamProcessing
                     if (t.Kind == MessageKind.DataBatch)
                     {
                         var mt = t.Message.MinTimestamp;
-                        if (mt < lastSync) throw new StreamProcessingException("Out-of-order event received during Cache() call");
+                        if (mt < lastSync) throw new StreamProcessingOutOfOrderException("Out-of-order event received during Cache() call");
 
                         lastSync = mt;
 

--- a/Sources/Core/Microsoft.StreamProcessing/Exceptions.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Exceptions.cs
@@ -51,4 +51,28 @@ namespace Microsoft.StreamProcessing
         /// <param name="innerException">The additional exception being bundled with this exception.</param>
         public StreamProcessingException(string message, Exception innerException) : base(message, innerException) { }
     }
+
+    /// <summary>
+    /// Exception when Trill detects an out of order event outside of ingress
+    /// </summary>
+    public sealed class StreamProcessingOutOfOrderException : Exception
+    {
+        /// <summary>
+        /// Create ann out-of-order exception with no underlying message.
+        /// </summary>
+        public StreamProcessingOutOfOrderException() : base() { }
+
+        /// <summary>
+        /// Create an out-of-order exception with the given message.
+        /// </summary>
+        /// <param name="message">The error message associated with the exception.</param>
+        public StreamProcessingOutOfOrderException(string message) : base(message) { }
+
+        /// <summary>
+        /// Create an out-of-order exception with the given message and given inner exception.
+        /// </summary>
+        /// <param name="message">The error message associated with the exception.</param>
+        /// <param name="innerException">The additional exception being bundled with this exception.</param>
+        public StreamProcessingOutOfOrderException(string message, Exception innerException) : base(message, innerException) { }
+    }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/AlterLifetimeConstantDurationPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/AlterLifetimeConstantDurationPipe.cs
@@ -113,7 +113,7 @@ namespace Microsoft.StreamProcessing
                     }
                     if (vsync[i] < this.lastSync)
                     {
-                        throw new InvalidOperationException(
+                        throw new StreamProcessingOutOfOrderException(
                             "The operator AlterLifetime produced output out of sync-time order on an input event. The current internal sync time is " + this.lastSync.ToString(CultureInfo.InvariantCulture)
                             + ". The event's sync time is " + vsync[i].ToString(CultureInfo.InvariantCulture)
                             + ". The event's value is " + batch[i].ToString() + ".");

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/AlterLifetimeStartDependentDurationPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/AlterLifetimeStartDependentDurationPipe.cs
@@ -109,7 +109,7 @@ namespace Microsoft.StreamProcessing
                     }
                     if (vsync[i] < this.lastSync)
                     {
-                        throw new InvalidOperationException(
+                        throw new StreamProcessingOutOfOrderException(
                             "The operator AlterLifetime produced output out of sync-time order on an input event. The current internal sync time is " + this.lastSync.ToString(CultureInfo.InvariantCulture)
                             + ". The event's sync time is " + vsync[i].ToString(CultureInfo.InvariantCulture)
                             + ". The event's value is " + batch[i].ToString() + ".");

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/AlterLifetimeVariableDurationPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/AlterLifetimeVariableDurationPipe.cs
@@ -120,7 +120,7 @@ namespace Microsoft.StreamProcessing
                     }
                     if (vsync[i] < this.lastSync)
                     {
-                        throw new InvalidOperationException(
+                        throw new StreamProcessingOutOfOrderException(
                             "The operator AlterLifetime produced output out of sync-time order on an input event. The current internal sync time is " + this.lastSync.ToString(CultureInfo.InvariantCulture)
                             + ". The event's sync time is " + vsync[i].ToString(CultureInfo.InvariantCulture)
                             + ". The event's value is " + batch[i].ToString() + ".");

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/PartitionedAlterLifetimeConstantDurationPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/PartitionedAlterLifetimeConstantDurationPipe.cs
@@ -128,7 +128,7 @@ namespace Microsoft.StreamProcessing
                     }
                     else if (vsync[i] < this.lastSync.entries[index].value)
                     {
-                        throw new InvalidOperationException(
+                        throw new StreamProcessingOutOfOrderException(
                             "The operator AlterLifetime produced output out of sync-time order on an input event. The current internal sync time is " + this.lastSync.entries[index].value
                           + ". The event's sync time is " + vsync[i].ToString(CultureInfo.InvariantCulture)
                           + ". The event's partition key is " + partition.ToString()

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/PartitionedAlterLifetimeStartDependentDurationPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/PartitionedAlterLifetimeStartDependentDurationPipe.cs
@@ -128,7 +128,7 @@ namespace Microsoft.StreamProcessing
                     }
                     else if (vsync[i] < this.lastSync.entries[index].value)
                     {
-                        throw new InvalidOperationException(
+                        throw new StreamProcessingOutOfOrderException(
                             "The operator AlterLifetime produced output out of sync-time order on an input event. The current internal sync time is " + this.lastSync.entries[index].value
                           + ". The event's sync time is " + vsync[i].ToString(CultureInfo.InvariantCulture)
                           + ". The event's partition key is " + partition.ToString()

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/PartitionedAlterLifetimeVariableDurationByKeyPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/PartitionedAlterLifetimeVariableDurationByKeyPipe.cs
@@ -128,7 +128,7 @@ namespace Microsoft.StreamProcessing
                 }
                 else if (vsync[i] < this.lastSync.entries[index].value)
                 {
-                    throw new InvalidOperationException(
+                    throw new StreamProcessingOutOfOrderException(
                         "The operator AlterLifetime produced output out of sync-time order on an input event. The current internal sync time is " + this.lastSync.entries[index].value
                         + ". The event's sync time is " + vsync[i].ToString(CultureInfo.InvariantCulture)
                         + ". The event's partition key is " + partition.ToString()

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/PartitionedAlterLifetimeVariableDurationPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/AlterLifetime/PartitionedAlterLifetimeVariableDurationPipe.cs
@@ -137,7 +137,7 @@ namespace Microsoft.StreamProcessing
                 }
                 else if (vsync[i] < this.lastSync.entries[index].value)
                 {
-                    throw new InvalidOperationException(
+                    throw new StreamProcessingOutOfOrderException(
                         "The operator AlterLifetime produced output out of sync-time order on an input event. The current internal sync time is " + this.lastSync.entries[index].value
                         + ". The event's sync time is " + vsync[i].ToString(CultureInfo.InvariantCulture)
                         + ". The event's partition key is " + partition.ToString()

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/ClipJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/ClipJoinPipe.cs
@@ -395,7 +395,7 @@ namespace Microsoft.StreamProcessing
         {
             if (start < this.lastCTI)
             {
-                throw new InvalidOperationException("Outputting an event out of order!");
+                throw new StreamProcessingOutOfOrderException("Outputting an event out of order!");
             }
 
             int index = this.output.Count++;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/ClipJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/ClipJoinPipe.cs
@@ -25,12 +25,26 @@ namespace Microsoft.StreamProcessing
 
         [DataMember]
         private StreamMessage<TKey, TLeft> output;
+
+        /// <summary>
+        /// Stores intervals for active left events.
+        /// </summary>
         [DataMember]
         private FastMap<LeftInterval> leftIntervalMap = new FastMap<LeftInterval>();
+
+        /// <summary>
+        /// Stores left start edges at <see cref="currTime"/>
+        /// </summary>
         [DataMember]
         private FastMap<LeftEdge> leftEdgeMap = new FastMap<LeftEdge>();
+
+        /// <summary>
+        /// Stores left end edges at some point in the future, i.e. after <see cref="currTime"/>.
+        /// These can originate from edge end events or interval events.
+        /// </summary>
         [DataMember]
         private RemovableEndPointHeap leftEndPointHeap;
+
         [DataMember]
         private long nextLeftTime = long.MinValue;
         [DataMember]
@@ -379,6 +393,11 @@ namespace Microsoft.StreamProcessing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AddToBatch(long start, long end, ref TKey key, ref TLeft payload, int hash)
         {
+            if (start < this.lastCTI)
+            {
+                throw new InvalidOperationException("Outputting an event out of order!");
+            }
+
             int index = this.output.Count++;
             this.output.vsync.col[index] = start;
             this.output.vother.col[index] = end;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/PartitionedClipJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/PartitionedClipJoinPipe.cs
@@ -347,8 +347,8 @@ namespace Microsoft.StreamProcessing
                             partition.nextRightTime = this.lastRightCTI;
 
                         UpdateTime(partition, Math.Min(this.lastLeftCTI, this.lastRightCTI));
-                        if (partition.IsClean())
-                            this.cleanKeys.Add(pKey);
+                        if (partition.IsClean()) this.cleanKeys.Add(pKey);
+
                         break;
                     }
                 }
@@ -361,21 +361,9 @@ namespace Microsoft.StreamProcessing
                 this.emitCTI = false;
                 foreach (var p in this.cleanKeys)
                 {
-                    this.leftQueue.Lookup(p, out int index);
-                    var l = this.leftQueue.entries[index];
-                    var r = this.rightQueue.entries[index];
-                    if (l.value.Count == 0 && r.value.Count == 0)
-                    {
-                        this.partitionData.Lookup(p, out index);
-                        var partition = this.partitionData.entries[index].value;
-
-                        if (partition.IsClean())
-                        {
-                            this.seenKeys.Remove(p);
-                            this.leftQueue.Remove(p);
-                            this.rightQueue.Remove(p);
-                        }
-                    }
+                    this.seenKeys.Remove(p);
+                    this.leftQueue.Remove(p);
+                    this.rightQueue.Remove(p);
                 }
 
                 this.cleanKeys.Clear();
@@ -555,7 +543,7 @@ namespace Microsoft.StreamProcessing
         {
             if (start < this.lastCTI)
             {
-                throw new InvalidOperationException("Outputting an event out of order!");
+                throw new StreamProcessingOutOfOrderException("Outputting an event out of order!");
             }
 
             int index = this.output.Count++;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/PartitionedClipJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Clip/PartitionedClipJoinPipe.cs
@@ -347,7 +347,8 @@ namespace Microsoft.StreamProcessing
                             partition.nextRightTime = this.lastRightCTI;
 
                         UpdateTime(partition, Math.Min(this.lastLeftCTI, this.lastRightCTI));
-                        this.cleanKeys.Add(pKey);
+                        if (partition.IsClean())
+                            this.cleanKeys.Add(pKey);
                         break;
                     }
                 }
@@ -365,9 +366,15 @@ namespace Microsoft.StreamProcessing
                     var r = this.rightQueue.entries[index];
                     if (l.value.Count == 0 && r.value.Count == 0)
                     {
-                        this.seenKeys.Remove(p);
-                        this.leftQueue.Remove(p);
-                        this.rightQueue.Remove(p);
+                        this.partitionData.Lookup(p, out index);
+                        var partition = this.partitionData.entries[index].value;
+
+                        if (partition.IsClean())
+                        {
+                            this.seenKeys.Remove(p);
+                            this.leftQueue.Remove(p);
+                            this.rightQueue.Remove(p);
+                        }
                     }
                 }
 
@@ -546,6 +553,11 @@ namespace Microsoft.StreamProcessing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AddToBatch(long start, long end, ref TKey key, ref TLeft payload, int hash)
         {
+            if (start < this.lastCTI)
+            {
+                throw new InvalidOperationException("Outputting an event out of order!");
+            }
+
             int index = this.output.Count++;
             this.output.vsync.col[index] = start;
             this.output.vother.col[index] = end;
@@ -731,18 +743,33 @@ namespace Microsoft.StreamProcessing
 
         private sealed class PartitionEntry
         {
+            /// <summary>
+            /// Stores intervals for active left events.
+            /// </summary>
             [DataMember]
             public FastMap<LeftInterval> leftIntervalMap = new FastMap<LeftInterval>();
+
+            /// <summary>
+            /// Stores left start edges at <see cref="currTime"/>
+            /// </summary>
             [DataMember]
             public FastMap<LeftEdge> leftEdgeMap = new FastMap<LeftEdge>();
+
+            /// <summary>
+            /// Stores left end edges at some point in the future, i.e. after <see cref="currTime"/>.
+            /// These can originate from edge end events or interval events.
+            /// </summary>
             [DataMember]
             public RemovableEndPointHeap leftEndPointHeap = new RemovableEndPointHeap();
+
             [DataMember]
             public long nextLeftTime = long.MinValue;
             [DataMember]
             public long nextRightTime = long.MinValue;
             [DataMember]
             public long currTime = long.MinValue;
+
+            public bool IsClean() => this.leftIntervalMap.IsEmpty && this.leftEdgeMap.IsEmpty && this.leftEndPointHeap.IsEmpty;
         }
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/EquiJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/EquiJoinPipe.cs
@@ -875,7 +875,7 @@ namespace Microsoft.StreamProcessing
         {
             if (start < this.lastCTI)
             {
-                throw new InvalidOperationException("Outputting an event out of order!");
+                throw new StreamProcessingOutOfOrderException("Outputting an event out of order!");
             }
 
             int index = this.output.Count++;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipe.cs
@@ -413,8 +413,8 @@ namespace Microsoft.StreamProcessing
                             UpdateNextRightTime(partition, this.lastRightCTI);
 
                         UpdateTime(partition, Math.Min(this.lastLeftCTI, this.lastRightCTI));
-                        if (partition.IsClean())
-                            this.cleanKeys.Add(pKey);
+                        if (partition.IsClean()) this.cleanKeys.Add(pKey);
+
                         break;
                     }
                 }
@@ -427,21 +427,9 @@ namespace Microsoft.StreamProcessing
                 this.emitCTI = false;
                 foreach (var p in this.cleanKeys)
                 {
-                    this.leftQueue.Lookup(p, out int index);
-                    var l = this.leftQueue.entries[index];
-                    var r = this.rightQueue.entries[index];
-                    if (l.value.Count == 0 && r.value.Count == 0)
-                    {
-                        this.partitionData.Lookup(p, out index);
-                        var partition = this.partitionData.entries[index].value;
-
-                        if (partition.IsClean())
-                        {
-                            this.seenKeys.Remove(p);
-                            this.leftQueue.Remove(p);
-                            this.rightQueue.Remove(p);
-                        }
-                    }
+                    this.seenKeys.Remove(p);
+                    this.leftQueue.Remove(p);
+                    this.rightQueue.Remove(p);
                 }
 
                 this.cleanKeys.Clear();
@@ -984,7 +972,7 @@ namespace Microsoft.StreamProcessing
         {
             if (start < this.lastCTI)
             {
-                throw new InvalidOperationException("Outputting an event out of order!");
+                throw new StreamProcessingOutOfOrderException("Outputting an event out of order!");
             }
 
             int index = this.output.Count++;
@@ -1246,15 +1234,11 @@ namespace Microsoft.StreamProcessing
             [DataMember]
             public long currTime = long.MinValue;
 
-            public bool IsClean()
-            {
-                return
-                    this.leftIntervalMap.IsEmpty &&
-                    this.leftEdgeMap.IsEmpty &&
-                    this.endPointHeap.IsEmpty &&
-                    this.rightIntervalMap.IsEmpty &&
-                    this.rightEdgeMap.IsEmpty;
-            }
+            public bool IsClean() => this.leftIntervalMap.IsEmpty &&
+                                     this.leftEdgeMap.IsEmpty &&
+                                     this.endPointHeap.IsEmpty &&
+                                     this.rightIntervalMap.IsEmpty &&
+                                     this.rightEdgeMap.IsEmpty;
         }
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeCompound.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeCompound.cs
@@ -417,7 +417,8 @@ namespace Microsoft.StreamProcessing
                             UpdateNextRightTime(partition, this.lastRightCTI);
 
                         UpdateTime(partition, Math.Min(this.lastLeftCTI, this.lastRightCTI));
-                        this.cleanKeys.Add(pKey);
+                        if (partition.IsClean())
+                            this.cleanKeys.Add(pKey);
                         break;
                     }
                 }
@@ -435,9 +436,15 @@ namespace Microsoft.StreamProcessing
                     var r = this.rightQueue.entries[index];
                     if (l.value.Count == 0 && r.value.Count == 0)
                     {
-                        this.seenKeys.Remove(p);
-                        this.leftQueue.Remove(p);
-                        this.rightQueue.Remove(p);
+                        this.partitionData.Lookup(p, out index);
+                        var partition = this.partitionData.entries[index].value;
+
+                        if (partition.IsClean())
+                        {
+                            this.seenKeys.Remove(p);
+                            this.leftQueue.Remove(p);
+                            this.rightQueue.Remove(p);
+                        }
                     }
                 }
 
@@ -571,7 +578,7 @@ namespace Microsoft.StreamProcessing
             {
                 // Row is an end edge.
 
-                // Remove from leftEdgeMap.
+                // Remove from rightEdgeMap.
                 if (!partition.isLeftComplete)
                 {
                     var edges = partition.rightEdgeMap.Find(hash);
@@ -993,6 +1000,11 @@ namespace Microsoft.StreamProcessing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AddToBatch(long start, long end, ref TGroupKey key, ref TPartitionKey pKey, ref TLeft leftPayload, ref TRight rightPayload, int hash)
         {
+            if (start < this.lastCTI)
+            {
+                throw new InvalidOperationException("Outputting an event out of order!");
+            }
+
             int index = this.output.Count++;
             this.output.vsync.col[index] = start;
             this.output.vother.col[index] = end;
@@ -1191,26 +1203,76 @@ namespace Microsoft.StreamProcessing
         {
             [DataMember]
             public TPartitionKey key;
+
+            /// <summary>
+            /// Stores left intervals starting at <see cref="currTime"/>.
+            /// FastMap visibility means that <see cref="nextRightTime"/> is caught up to the left edge time and the
+            /// left edge is processable.
+            /// </summary>
             [DataMember]
             public FastMap<ActiveInterval<TLeft>> leftIntervalMap = new FastMap<ActiveInterval<TLeft>>();
+
+            /// <summary>
+            /// Stores left start edges at <see cref="currTime"/>
+            /// FastMap visibility means that <see cref="nextRightTime"/> is caught up to the left edge time and the
+            /// left edge is processable.
+            /// </summary>
             [DataMember]
             public FastMap<ActiveEdge<TLeft>> leftEdgeMap = new FastMap<ActiveEdge<TLeft>>();
+
+            /// <summary>
+            /// Stores end edges for the current join at some point in the future, i.e. after <see cref="currTime"/>.
+            /// These can originate from edge end events or interval events.
+            /// </summary>
             [DataMember]
             public IEndPointOrderer endPointHeap;
+
+            /// <summary>
+            /// Stores right intervals starting at <see cref="currTime"/>.
+            /// FastMap visibility means that <see cref="nextRightTime"/> is caught up to the right edge time and the
+            /// right edge is processable.
+            /// </summary>
             [DataMember]
             public FastMap<ActiveInterval<TRight>> rightIntervalMap = new FastMap<ActiveInterval<TRight>>();
+
+            /// <summary>
+            /// Stores right start edges at <see cref="currTime"/>
+            /// FastMap visibility means that <see cref="nextRightTime"/> is caught up to the right edge time and the
+            /// right edge is processable.
+            /// </summary>
             [DataMember]
             public FastMap<ActiveEdge<TRight>> rightEdgeMap = new FastMap<ActiveEdge<TRight>>();
+
             [DataMember]
             public long nextLeftTime = long.MinValue;
+
+            /// <summary>
+            /// True if left has reached StreamEvent.InfinitySyncTime
+            /// </summary>
             [DataMember]
             public bool isLeftComplete = false;
+
             [DataMember]
             public long nextRightTime = long.MinValue;
+
+            /// <summary>
+            /// True if right has reached StreamEvent.InfinitySyncTime
+            /// </summary>
             [DataMember]
             public bool isRightComplete = false;
+
             [DataMember]
             public long currTime = long.MinValue;
+
+            public bool IsClean()
+            {
+                return
+                    this.leftIntervalMap.IsEmpty &&
+                    this.leftEdgeMap.IsEmpty &&
+                    this.endPointHeap.IsEmpty &&
+                    this.rightIntervalMap.IsEmpty &&
+                    this.rightEdgeMap.IsEmpty;
+            }
         }
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeCompound.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeCompound.cs
@@ -417,8 +417,8 @@ namespace Microsoft.StreamProcessing
                             UpdateNextRightTime(partition, this.lastRightCTI);
 
                         UpdateTime(partition, Math.Min(this.lastLeftCTI, this.lastRightCTI));
-                        if (partition.IsClean())
-                            this.cleanKeys.Add(pKey);
+                        if (partition.IsClean()) this.cleanKeys.Add(pKey);
+
                         break;
                     }
                 }
@@ -431,21 +431,9 @@ namespace Microsoft.StreamProcessing
                 this.emitCTI = false;
                 foreach (var p in this.cleanKeys)
                 {
-                    this.leftQueue.Lookup(p, out int index);
-                    var l = this.leftQueue.entries[index];
-                    var r = this.rightQueue.entries[index];
-                    if (l.value.Count == 0 && r.value.Count == 0)
-                    {
-                        this.partitionData.Lookup(p, out index);
-                        var partition = this.partitionData.entries[index].value;
-
-                        if (partition.IsClean())
-                        {
-                            this.seenKeys.Remove(p);
-                            this.leftQueue.Remove(p);
-                            this.rightQueue.Remove(p);
-                        }
-                    }
+                    this.seenKeys.Remove(p);
+                    this.leftQueue.Remove(p);
+                    this.rightQueue.Remove(p);
                 }
 
                 this.cleanKeys.Clear();
@@ -1002,7 +990,7 @@ namespace Microsoft.StreamProcessing
         {
             if (start < this.lastCTI)
             {
-                throw new InvalidOperationException("Outputting an event out of order!");
+                throw new StreamProcessingOutOfOrderException("Outputting an event out of order!");
             }
 
             int index = this.output.Count++;
@@ -1264,15 +1252,11 @@ namespace Microsoft.StreamProcessing
             [DataMember]
             public long currTime = long.MinValue;
 
-            public bool IsClean()
-            {
-                return
-                    this.leftIntervalMap.IsEmpty &&
-                    this.leftEdgeMap.IsEmpty &&
-                    this.endPointHeap.IsEmpty &&
-                    this.rightIntervalMap.IsEmpty &&
-                    this.rightEdgeMap.IsEmpty;
-            }
+            public bool IsClean() => this.leftIntervalMap.IsEmpty &&
+                                     this.leftEdgeMap.IsEmpty &&
+                                     this.endPointHeap.IsEmpty &&
+                                     this.rightIntervalMap.IsEmpty &&
+                                     this.rightEdgeMap.IsEmpty;
         }
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeSimple.cs
@@ -397,8 +397,8 @@ namespace Microsoft.StreamProcessing
                             UpdateNextRightTime(partition, this.lastRightCTI);
 
                         UpdateTime(partition, Math.Min(this.lastLeftCTI, this.lastRightCTI));
-                        if (partition.IsClean())
-                            this.cleanKeys.Add(pKey);
+                        if (partition.IsClean()) this.cleanKeys.Add(pKey);
+
                         break;
                     }
                 }
@@ -411,21 +411,9 @@ namespace Microsoft.StreamProcessing
                 this.emitCTI = false;
                 foreach (var p in this.cleanKeys)
                 {
-                    this.leftQueue.Lookup(p, out int index);
-                    var l = this.leftQueue.entries[index];
-                    var r = this.rightQueue.entries[index];
-                    if (l.value.Count == 0 && r.value.Count == 0)
-                    {
-                        this.partitionData.Lookup(p, out index);
-                        var partition = this.partitionData.entries[index].value;
-
-                        if (partition.IsClean())
-                        {
-                            this.seenKeys.Remove(p);
-                            this.leftQueue.Remove(p);
-                            this.rightQueue.Remove(p);
-                        }
-                    }
+                    this.seenKeys.Remove(p);
+                    this.leftQueue.Remove(p);
+                    this.rightQueue.Remove(p);
                 }
 
                 this.cleanKeys.Clear();
@@ -900,7 +888,7 @@ namespace Microsoft.StreamProcessing
         {
             if (start < this.lastCTI)
             {
-                throw new InvalidOperationException("Outputting an event out of order!");
+                throw new StreamProcessingOutOfOrderException("Outputting an event out of order!");
             }
 
             int index = this.output.Count++;
@@ -1150,15 +1138,11 @@ namespace Microsoft.StreamProcessing
             [DataMember]
             public long currTime = long.MinValue;
 
-            public bool IsClean()
-            {
-                return
-                    this.leftIntervalMap.IsEmpty &&
-                    this.leftEdgeMap.IsEmpty &&
-                    this.endPointHeap.IsEmpty &&
-                    this.rightIntervalMap.IsEmpty &&
-                    this.rightEdgeMap.IsEmpty;
-            }
+            public bool IsClean() => this.leftIntervalMap.IsEmpty &&
+                                     this.leftEdgeMap.IsEmpty &&
+                                     this.endPointHeap.IsEmpty &&
+                                     this.rightIntervalMap.IsEmpty &&
+                                     this.rightEdgeMap.IsEmpty;
         }
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeSimple.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/Basic/PartitionedEquiJoinPipeSimple.cs
@@ -397,7 +397,8 @@ namespace Microsoft.StreamProcessing
                             UpdateNextRightTime(partition, this.lastRightCTI);
 
                         UpdateTime(partition, Math.Min(this.lastLeftCTI, this.lastRightCTI));
-                        this.cleanKeys.Add(pKey);
+                        if (partition.IsClean())
+                            this.cleanKeys.Add(pKey);
                         break;
                     }
                 }
@@ -415,9 +416,15 @@ namespace Microsoft.StreamProcessing
                     var r = this.rightQueue.entries[index];
                     if (l.value.Count == 0 && r.value.Count == 0)
                     {
-                        this.seenKeys.Remove(p);
-                        this.leftQueue.Remove(p);
-                        this.rightQueue.Remove(p);
+                        this.partitionData.Lookup(p, out index);
+                        var partition = this.partitionData.entries[index].value;
+
+                        if (partition.IsClean())
+                        {
+                            this.seenKeys.Remove(p);
+                            this.leftQueue.Remove(p);
+                            this.rightQueue.Remove(p);
+                        }
                     }
                 }
 
@@ -891,6 +898,11 @@ namespace Microsoft.StreamProcessing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AddToBatch(long start, long end, PartitionEntry partition, ref TLeft leftPayload, ref TRight rightPayload)
         {
+            if (start < this.lastCTI)
+            {
+                throw new InvalidOperationException("Outputting an event out of order!");
+            }
+
             int index = this.output.Count++;
             this.output.vsync.col[index] = start;
             this.output.vother.col[index] = end;
@@ -1077,26 +1089,76 @@ namespace Microsoft.StreamProcessing
             public TPartitionKey key;
             [DataMember]
             public int hash;
+
+            /// <summary>
+            /// Stores left intervals starting at <see cref="currTime"/>.
+            /// FastMap visibility means that <see cref="nextRightTime"/> is caught up to the left edge time and the
+            /// left edge is processable.
+            /// </summary>
             [DataMember]
             public FastMap<ActiveInterval<TLeft>> leftIntervalMap = new FastMap<ActiveInterval<TLeft>>();
+
+            /// <summary>
+            /// Stores left start edges at <see cref="currTime"/>
+            /// FastMap visibility means that <see cref="nextRightTime"/> is caught up to the left edge time and the
+            /// left edge is processable.
+            /// </summary>
             [DataMember]
             public FastMap<ActiveEdge<TLeft>> leftEdgeMap = new FastMap<ActiveEdge<TLeft>>();
+
+            /// <summary>
+            /// Stores end edges for the current join at some point in the future, i.e. after <see cref="currTime"/>.
+            /// These can originate from edge end events or interval events.
+            /// </summary>
             [DataMember]
             public IEndPointOrderer endPointHeap;
+
+            /// <summary>
+            /// Stores right intervals starting at <see cref="currTime"/>.
+            /// FastMap visibility means that <see cref="nextRightTime"/> is caught up to the right edge time and the
+            /// right edge is processable.
+            /// </summary>
             [DataMember]
             public FastMap<ActiveInterval<TRight>> rightIntervalMap = new FastMap<ActiveInterval<TRight>>();
+
+            /// <summary>
+            /// Stores right start edges at <see cref="currTime"/>
+            /// FastMap visibility means that <see cref="nextRightTime"/> is caught up to the right edge time and the
+            /// right edge is processable.
+            /// </summary>
             [DataMember]
             public FastMap<ActiveEdge<TRight>> rightEdgeMap = new FastMap<ActiveEdge<TRight>>();
+
             [DataMember]
             public long nextLeftTime = long.MinValue;
+
+            /// <summary>
+            /// True if left has reached StreamEvent.InfinitySyncTime
+            /// </summary>
             [DataMember]
             public bool isLeftComplete = false;
+
             [DataMember]
             public long nextRightTime = long.MinValue;
+
+            /// <summary>
+            /// True if right has reached StreamEvent.InfinitySyncTime
+            /// </summary>
             [DataMember]
             public bool isRightComplete = false;
+
             [DataMember]
             public long currTime = long.MinValue;
+
+            public bool IsClean()
+            {
+                return
+                    this.leftIntervalMap.IsEmpty &&
+                    this.leftEdgeMap.IsEmpty &&
+                    this.endPointHeap.IsEmpty &&
+                    this.rightIntervalMap.IsEmpty &&
+                    this.rightEdgeMap.IsEmpty;
+            }
         }
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/StartEdge/PartitionedStartEdgeEquiJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/EquiJoin/StartEdge/PartitionedStartEdgeEquiJoinPipe.cs
@@ -590,20 +590,36 @@ namespace Microsoft.StreamProcessing
         {
             [DataMember]
             public TPartitionKey key;
+
+            /// <summary>
+            /// Currently active left start edges
+            /// </summary>
             [DataMember]
             public FastMap<ActiveEvent<TLeft>> leftEdgeMap = new FastMap<ActiveEvent<TLeft>>();
+
+            /// <summary>
+            /// Currently active right start edges
+            /// </summary>
             [DataMember]
             public FastMap<ActiveEvent<TRight>> rightEdgeMap = new FastMap<ActiveEvent<TRight>>();
+
             [DataMember]
             public long nextLeftTime = long.MinValue;
+
+            /// <summary>
+            /// True if left has reached StreamEvent.InfinitySyncTime
+            /// </summary>
             [DataMember]
             public bool isLeftComplete = false;
+
             [DataMember]
             public long nextRightTime = long.MinValue;
+
+            /// <summary>
+            /// True if right has reached StreamEvent.InfinitySyncTime
+            /// </summary>
             [DataMember]
             public bool isRightComplete = false;
-            [DataMember]
-            public long currTime = long.MinValue;
         }
     }
 }

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/LeftAntiSemiJoin/LeftAntiSemiJoinPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/LeftAntiSemiJoin/LeftAntiSemiJoinPipe.cs
@@ -706,7 +706,7 @@ namespace Microsoft.StreamProcessing
         {
             if (start < this.lastCTI)
             {
-                throw new InvalidOperationException("Outputting an event out of order!");
+                throw new StreamProcessingOutOfOrderException("Outputting an event out of order!");
             }
 
             int index = this.output.Count++;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Union/PartitionedUnionPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Union/PartitionedUnionPipe.cs
@@ -322,6 +322,11 @@ namespace Microsoft.StreamProcessing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void OutputCurrentTuple(Entry current)
         {
+            if (current.Sync < this.lastCTI)
+            {
+                throw new InvalidOperationException("Outputting an event out of order!");
+            }
+
             int index = this.output.Count++;
             this.output.vsync.col[index] = current.Sync;
             this.output.vother.col[index] = current.Other;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Union/PartitionedUnionPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Union/PartitionedUnionPipe.cs
@@ -324,7 +324,7 @@ namespace Microsoft.StreamProcessing
         {
             if (current.Sync < this.lastCTI)
             {
-                throw new InvalidOperationException("Outputting an event out of order!");
+                throw new StreamProcessingOutOfOrderException("Outputting an event out of order!");
             }
 
             int index = this.output.Count++;


### PR DESCRIPTION
Several partitioned binary operators attempt to clean up limited state for dry partitions, but do so too aggressively for a particular pattern. When a partition is removed from the operator's "seenKeys", that partition is no longer processed when the operator receives a low watermark. When the removed partition had pending state that needs to be processed, and when the operator has stateful processing in response to the lwm, this can lead to incorrect/missing output events and/or events egressed out of order.

The fix is to check whether the partition to be removed has any pending state that needs to be processed before removing it.

I'm also taking the opportunity to add some validation that we do not egress events before the last LWM for these operators, which should reduce debugging time for the next out of order bug caught by ASA.