### PR TITLE
Fixing out of order bug in Partitioned SnapshotWindow variants

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/PartitionedSnapshotWindowHoppingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/PartitionedSnapshotWindowHoppingPipe.cs
@@ -284,10 +284,10 @@ namespace Microsoft.StreamProcessing
                     {
                         foreach (var ecqState in partition.ecq.Iterate())
                         {
-                            iter = FastDictionary<TKey, StateAndActive<TState>>.IteratorStart;
-                            while (ecqState.states.Iterate(ref iter))
+                            var stateIter = FastDictionary<TKey, StateAndActive<TState>>.IteratorStart;
+                            while (ecqState.states.Iterate(ref stateIter))
                             {
-                                if (ecqState.states.entries[iter].value.active > 0)
+                                if (ecqState.states.entries[stateIter].value.active > 0)
                                 {
                                     partitionHasValidOutstandingState = true;
                                     break;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/PartitionedSnapshotWindowPriorityQueuePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/PartitionedSnapshotWindowPriorityQueuePipe.cs
@@ -263,11 +263,10 @@ namespace Microsoft.StreamProcessing
                     {
                         foreach (var ecqState in partition.ecq)
                         {
-                            iter = FastDictionary<TKey, StateAndActive<TState>>.IteratorStart;
-                            int index = FastDictionary<TKey, StateAndActive<TState>>.IteratorStart;
-                            while (ecqState.Value.Iterate(ref index))
+                            var stateIter = FastDictionary<TKey, StateAndActive<TState>>.IteratorStart;
+                            while (ecqState.Value.Iterate(ref stateIter))
                             {
-                                if (ecqState.Value.entries[index].value.active > 0)
+                                if (ecqState.Value.entries[stateIter].value.active > 0)
                                 {
                                     partitionHasValidOutstandingState = true;
                                     break;

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/PartitionedSnapshotWindowSlidingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/PartitionedSnapshotWindowSlidingPipe.cs
@@ -282,10 +282,10 @@ namespace Microsoft.StreamProcessing
                     {
                         foreach (var ecqState in partition.ecq)
                         {
-                            iter = FastDictionary<TKey, StateAndActive<TState>>.IteratorStart;
-                            while (ecqState.states.Iterate(ref iter))
+                            var stateIter = FastDictionary<TKey, StateAndActive<TState>>.IteratorStart;
+                            while (ecqState.states.Iterate(ref stateIter))
                             {
-                                if (ecqState.states.entries[iter].value.active > 0)
+                                if (ecqState.states.entries[stateIter].value.active > 0)
                                 {
                                     partitionHasValidOutstandingState = true;
                                     break;


### PR DESCRIPTION
Fixing out of order bug in Partitioned SnapshotWindow variants. When a partitioned stream has multiple aggregation states per partition and we receive a low watermark, the pipes attempt to iterate over the partitions and states to determine which partitions can be cleaned up/removed. However, the nested iterations used the same iterator, so the nested loop overwrites the outer loop, resulting in some partitions not being processed in response to the low watermark, delaying the output events that would have resulted until after the low watermark has already been inserted into the output batch.