### PR TITLE
Additional changes for better min/max inlining

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Aggregates/TumblingMinAggregate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Aggregates/TumblingMinAggregate.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics.Contracts;
 using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.StreamProcessing.Internal;
 
 namespace Microsoft.StreamProcessing.Aggregates
@@ -12,25 +13,45 @@ namespace Microsoft.StreamProcessing.Aggregates
     internal class TumblingMinAggregate<T> : IAggregate<T, MinMaxState<T>, T>
     {
         private static readonly long InvalidSyncTime = StreamEvent.MinSyncTime - 1;
-        private readonly Comparison<T> comparer;
+        private readonly Expression<Func<MinMaxState<T>, long, T, MinMaxState<T>>> accumulate;
 
         public TumblingMinAggregate() : this(ComparerExpression<T>.Default) { }
 
         public TumblingMinAggregate(IComparerExpression<T> comparer)
         {
             Contract.Requires(comparer != null);
-            this.comparer = comparer.GetCompareExpr().Compile();
+
+            var stateExpression = Expression.Parameter(typeof(MinMaxState<T>), "state");
+            var timestampExpression = Expression.Parameter(typeof(long), "timestamp");
+            var inputExpression = Expression.Parameter(typeof(T), "input");
+
+            Expression<Func<MinMaxState<T>>> constructor = () => new MinMaxState<T>();
+            Expression<Func<MinMaxState<T>, long>> currentTimestamp = (state) => state.currentTimestamp;
+            Expression<Func<MinMaxState<T>, T>> currentValue = (state) => state.currentValue;
+            var currentTimestampExpression = currentTimestamp.ReplaceParametersInBody(stateExpression);
+            var currentValueExpression = currentValue.ReplaceParametersInBody(stateExpression);
+            var comparerExpression = comparer.GetCompareExpr().ReplaceParametersInBody(inputExpression, currentValueExpression);
+
+            var typeInfo = typeof(MinMaxState<T>).GetTypeInfo();
+            this.accumulate = Expression.Lambda<Func<MinMaxState<T>, long, T, MinMaxState<T>>>(
+                Expression.MemberInit(
+                    (NewExpression)constructor.Body,
+                    Expression.Bind(typeInfo.GetField("currentTimestamp"), timestampExpression),
+                    Expression.Bind(typeInfo.GetField("currentValue"), Expression.Condition(
+                        Expression.Or(
+                            Expression.Equal(currentTimestampExpression, Expression.Constant(InvalidSyncTime)),
+                            Expression.LessThan(comparerExpression, Expression.Constant(0))),
+                        inputExpression,
+                        currentValueExpression))),
+                stateExpression,
+                timestampExpression,
+                inputExpression);
         }
 
         public Expression<Func<MinMaxState<T>>> InitialState()
             => () => new MinMaxState<T> { currentTimestamp = InvalidSyncTime };
 
-        public Expression<Func<MinMaxState<T>, long, T, MinMaxState<T>>> Accumulate()
-            => (state, timestamp, input) => new MinMaxState<T>
-            {
-                currentTimestamp = timestamp,
-                currentValue = (state.currentTimestamp == InvalidSyncTime || this.comparer(input, state.currentValue) < 0) ? input : state.currentValue
-            };
+        public Expression<Func<MinMaxState<T>, long, T, MinMaxState<T>>> Accumulate() => this.accumulate;
 
         public Expression<Func<MinMaxState<T>, long, T, MinMaxState<T>>> Deaccumulate()
             => (state, timestamp, input) => state; // never invoked, hence not implemented

--- a/Sources/Test/SimpleTesting/SnapshotTests.cs
+++ b/Sources/Test/SimpleTesting/SnapshotTests.cs
@@ -128,6 +128,33 @@ namespace SimpleTesting
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot5Row() // like 4, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1Row()
         {
             var input = new StreamEvent<MyData>[]
@@ -230,6 +257,34 @@ namespace SimpleTesting
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Sum(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot5Row() // like 5, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Max(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
@@ -811,6 +866,33 @@ namespace SimpleTesting
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot5RowSmallBatch() // like 4, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1RowSmallBatch()
         {
             var input = new StreamEvent<MyData>[]
@@ -913,6 +995,34 @@ namespace SimpleTesting
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Sum(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot5RowSmallBatch() // like 5, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Max(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
@@ -1493,6 +1603,33 @@ namespace SimpleTesting
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot5Columnar() // like 4, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1Columnar()
         {
             var input = new StreamEvent<MyData>[]
@@ -1595,6 +1732,34 @@ namespace SimpleTesting
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Sum(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot5Columnar() // like 5, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Max(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
@@ -2176,6 +2341,33 @@ namespace SimpleTesting
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot5ColumnarSmallBatch() // like 4, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1ColumnarSmallBatch()
         {
             var input = new StreamEvent<MyData>[]
@@ -2278,6 +2470,34 @@ namespace SimpleTesting
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Sum(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot5ColumnarSmallBatch() // like 5, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Max(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();

--- a/Sources/Test/SimpleTesting/SnapshotTests.tt
+++ b/Sources/Test/SimpleTesting/SnapshotTests.tt
@@ -152,6 +152,33 @@ foreach (var batch in new [] { string.Empty, "SmallBatch" })
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot5<#= suffix #>() // like 4, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1<#= suffix #>()
         {
             var input = new StreamEvent<MyData>[]
@@ -254,6 +281,34 @@ foreach (var batch in new [] { string.Empty, "SmallBatch" })
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Sum(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot5<#= suffix #>() // like 5, but with max
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Max(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();


### PR DESCRIPTION
Tumbling Min/Max aggregate operators were prevented from being inlined in compiled operators for two reasons:
- We were not accepting the option where a class implements IComparable, only IComparer. Thus we were defaulting to a sub-optimal comparer method
- We were not inlining the comparer expression into the accumulate method, therefore leaving the comparer expression as a closure constant.

This change addresses both issues - newly added tests run with 100% inlined accumulator code.