### PR TITLE
Reduce number of allocations of MinMaxState

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Aggregates/TumblingMinAggregate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Aggregates/TumblingMinAggregate.cs
@@ -29,20 +29,20 @@ namespace Microsoft.StreamProcessing.Aggregates
             Expression<Func<MinMaxState<T>, long>> currentTimestamp = (state) => state.currentTimestamp;
             Expression<Func<MinMaxState<T>, T>> currentValue = (state) => state.currentValue;
             var currentTimestampExpression = currentTimestamp.ReplaceParametersInBody(stateExpression);
-            var currentValueExpression = currentValue.ReplaceParametersInBody(stateExpression);
-            var comparerExpression = comparer.GetCompareExpr().ReplaceParametersInBody(inputExpression, currentValueExpression);
+            var comparerExpression = comparer.GetCompareExpr().ReplaceParametersInBody(
+                inputExpression, currentValue.ReplaceParametersInBody(stateExpression));
 
             var typeInfo = typeof(MinMaxState<T>).GetTypeInfo();
             this.accumulate = Expression.Lambda<Func<MinMaxState<T>, long, T, MinMaxState<T>>>(
-                Expression.MemberInit(
-                    (NewExpression)constructor.Body,
-                    Expression.Bind(typeInfo.GetField("currentTimestamp"), timestampExpression),
-                    Expression.Bind(typeInfo.GetField("currentValue"), Expression.Condition(
-                        Expression.Or(
-                            Expression.Equal(currentTimestampExpression, Expression.Constant(InvalidSyncTime)),
-                            Expression.LessThan(comparerExpression, Expression.Constant(0))),
-                        inputExpression,
-                        currentValueExpression))),
+                Expression.Condition(
+                    Expression.Or(
+                        Expression.Equal(currentTimestampExpression, Expression.Constant(InvalidSyncTime)),
+                        Expression.LessThan(comparerExpression, Expression.Constant(0))),
+                    Expression.MemberInit(
+                        (NewExpression)constructor.Body,
+                        Expression.Bind(typeInfo.GetField("currentTimestamp"), timestampExpression),
+                        Expression.Bind(typeInfo.GetField("currentValue"), inputExpression)),
+                    stateExpression),
                 stateExpression,
                 timestampExpression,
                 inputExpression);

--- a/Sources/Test/SimpleTesting/SnapshotTests.cs
+++ b/Sources/Test/SimpleTesting/SnapshotTests.cs
@@ -155,6 +155,33 @@ namespace SimpleTesting
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot6Row() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Min(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1Row()
         {
             var input = new StreamEvent<MyData>[]
@@ -285,6 +312,34 @@ namespace SimpleTesting
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot6Row() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 1),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Min(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
@@ -893,6 +948,33 @@ namespace SimpleTesting
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot6RowSmallBatch() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Min(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1RowSmallBatch()
         {
             var input = new StreamEvent<MyData>[]
@@ -1023,6 +1105,34 @@ namespace SimpleTesting
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot6RowSmallBatch() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 1),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Min(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
@@ -1630,6 +1740,33 @@ namespace SimpleTesting
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot6Columnar() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Min(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1Columnar()
         {
             var input = new StreamEvent<MyData>[]
@@ -1760,6 +1897,34 @@ namespace SimpleTesting
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot6Columnar() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 1),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Min(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
@@ -2368,6 +2533,33 @@ namespace SimpleTesting
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot6ColumnarSmallBatch() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Min(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1ColumnarSmallBatch()
         {
             var input = new StreamEvent<MyData>[]
@@ -2498,6 +2690,34 @@ namespace SimpleTesting
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot6ColumnarSmallBatch() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 1),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Min(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();

--- a/Sources/Test/SimpleTesting/SnapshotTests.tt
+++ b/Sources/Test/SimpleTesting/SnapshotTests.tt
@@ -179,6 +179,33 @@ foreach (var batch in new [] { string.Empty, "SmallBatch" })
         }
 
         [TestMethod, TestCategory("Gated")]
+        public void TumblingSnapshot6<#= suffix #>() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(10, 10)
+                .Min(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
         public void HoppingSnapshot1<#= suffix #>()
         {
             var input = new StreamEvent<MyData>[]
@@ -309,6 +336,34 @@ foreach (var batch in new [] { string.Empty, "SmallBatch" })
             var inputStream = input.ToObservable().ToStreamable();
             var query = inputStream.HoppingWindowLifetime(20, 10)
                 .Max(x => x.field1)
+                ;
+
+            var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
+
+        [TestMethod, TestCategory("Gated")]
+        public void HoppingSnapshot6<#= suffix #>() // like 5, but with min
+        {
+            var input = new StreamEvent<MyData>[]
+            {
+                StreamEvent.CreatePoint(11, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(12, new MyData { field1 = 1, field2 = "A" }),
+                StreamEvent.CreatePoint(21, new MyData { field1 = 2, field2 = "A" }),
+                StreamEvent.CreatePoint(25, new MyData { field1 = 2, field2 = "D" })
+            };
+
+            var expected = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateInterval(20, 30, 1),
+                StreamEvent.CreateInterval(30, 40, 1),
+                StreamEvent.CreateInterval(40, 50, 2),
+            };
+
+            var inputStream = input.ToObservable().ToStreamable();
+            var query = inputStream.HoppingWindowLifetime(20, 10)
+                .Min(x => x.field1)
                 ;
 
             var result = query.ToStreamEventObservable(ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData).ToEnumerable().ToArray();


### PR DESCRIPTION
The inlining of Tumbling min/max code resulted in a MinMaxState allocation on every row. This change moves the test for a new min or max to the outside of the constructor, reducing the number of allocations to only one per new min/max.

The worst case is still an allocation per row, but the best case is a single allocation.