### PR TITLE
Fix afa zero or one

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Collections/StreamMessage.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Collections/StreamMessage.cs
@@ -71,7 +71,7 @@ namespace Microsoft.StreamProcessing
     /// </summary>
     [DataContract]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class StreamMessage<TKey, TPayload> : StreamMessage // TODO: make this abstract
+    public class StreamMessage<TKey, TPayload> : StreamMessage
     {
         private const int M1 = 0x5555;
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/PatternMatcher.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/PatternMatcher.cs
@@ -392,6 +392,13 @@ namespace Microsoft.StreamProcessing
                     extraFinalStates.Add(oldFinal);
                     int oldMax = result.MaxState;
 
+                    // If the next pattern start state is also a final state, add it directly, as it will not necessarily have a transition entry
+                    if (nextPattern.finalStates.Contains(nextPattern.StartState))
+                    {
+                        if (!result.finalStates.Contains(oldFinal))
+                            result.finalStates.Add(oldFinal);
+                    }
+
                     foreach (var kvp1 in nextPattern.transitionInfo)
                     {
                         foreach (var kvp2 in kvp1.Value)

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/Regex.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/Regex.cs
@@ -609,6 +609,13 @@ namespace Microsoft.StreamProcessing
                     extraFinalStates.Add(oldFinal);
                     int oldMax = result.MaxState;
 
+                    // If the next pattern start state is also a final state, add it directly, as it will not necessarily have a transition entry
+                    if (nextPattern.finalStates.Contains(nextPattern.StartState))
+                    {
+                        if (!result.finalStates.Contains(oldFinal))
+                            result.finalStates.Add(oldFinal);
+                    }
+
                     foreach (var kvp1 in nextPattern.transitionInfo)
                     {
                         foreach (var kvp2 in kvp1.Value)

--- a/Sources/Test/SimpleTesting/Streamables/AfaTests.cs
+++ b/Sources/Test/SimpleTesting/Streamables/AfaTests.cs
@@ -515,21 +515,20 @@ namespace SimpleTesting
         public void AfaZeroOrOne()
         {
             var source = new StreamEvent<string>[]
-                {
-                    StreamEvent.CreateStart(0, "A"),
-                    StreamEvent.CreateStart(1, "C"),
-                    StreamEvent.CreateStart(2, "B"),
-                    StreamEvent.CreateStart(3, "B"),
-                    StreamEvent.CreateStart(4, "C"),
-                    StreamEvent.CreateStart(5, "A"),
-                    StreamEvent.CreateStart(6, "B"),
-                    StreamEvent.CreateStart(7, "B"),
-                    StreamEvent.CreateStart(8, "B"),
-                    StreamEvent.CreateStart(9, "A"),
-                }
-                .ToObservable()
+            {
+                StreamEvent.CreateStart(0, "A"),
+                StreamEvent.CreateStart(1, "C"),
+                StreamEvent.CreateStart(2, "B"),
+                StreamEvent.CreateStart(3, "B"),
+                StreamEvent.CreateStart(4, "C"),
+                StreamEvent.CreateStart(5, "A"),
+                StreamEvent.CreateStart(6, "B"),
+                StreamEvent.CreateStart(7, "B"),
+                StreamEvent.CreateStart(8, "B"),
+                StreamEvent.CreateStart(9, "A"),
+            }.ToObservable()
                 .ToStreamable()
-                .SetProperty().IsConstantDuration(true, StreamEvent.InfinitySyncTime);
+                .AlterEventDuration(2);
 
             var afa = ARegex.Concat(
                 ARegex.SingleElement<string, string>(
@@ -551,10 +550,10 @@ namespace SimpleTesting
                 .ToArray();
             var expected = new StreamEvent<string>[]
             {
-                StreamEvent.CreateStart(0, "A"),
-                StreamEvent.CreateStart(5, "A"),
-                StreamEvent.CreateStart(6, "AB"),
-                StreamEvent.CreateStart(9, "A"),
+                StreamEvent.CreateInterval(0, 2, "A"),
+                StreamEvent.CreateInterval(5, 7, "A"),
+                StreamEvent.CreateInterval(6, 7, "AB"),
+                StreamEvent.CreateInterval(9, 11, "A"),
             };
             Assert.IsTrue(result.SequenceEqual(expected));
         }

--- a/Sources/Test/SimpleTesting/Streamables/AfaTests.cs
+++ b/Sources/Test/SimpleTesting/Streamables/AfaTests.cs
@@ -510,6 +510,54 @@ namespace SimpleTesting
                 .ToList();
             Assert.IsTrue(registers.Count == 1 && registers[0].MatchedPayloads.Count == 1);
         }
+
+        [TestMethod, TestCategory("Gated")]
+        public void AfaZeroOrOne()
+        {
+            var source = new StreamEvent<string>[]
+                {
+                    StreamEvent.CreateStart(0, "A"),
+                    StreamEvent.CreateStart(1, "C"),
+                    StreamEvent.CreateStart(2, "B"),
+                    StreamEvent.CreateStart(3, "B"),
+                    StreamEvent.CreateStart(4, "C"),
+                    StreamEvent.CreateStart(5, "A"),
+                    StreamEvent.CreateStart(6, "B"),
+                    StreamEvent.CreateStart(7, "B"),
+                    StreamEvent.CreateStart(8, "B"),
+                    StreamEvent.CreateStart(9, "A"),
+                }
+                .ToObservable()
+                .ToStreamable()
+                .SetProperty().IsConstantDuration(true, StreamEvent.InfinitySyncTime);
+
+            var afa = ARegex.Concat(
+                ARegex.SingleElement<string, string>(
+                    (time, @event, state) => @event == "A",
+                    (time, @event, state) => @event),
+                ARegex.ZeroOrOne(
+                    ARegex.SingleElement<string, string>(
+                        (time, @event, state) => @event == "B",
+                        (time, @event, state) => state + @event)));
+
+            var result = source
+                .Detect(
+                    afa,
+                    allowOverlappingInstances: false,
+                    isDeterministic: false)
+                .ToStreamEventObservable()
+                .Where(evt => evt.IsData)
+                .ToEnumerable()
+                .ToArray();
+            var expected = new StreamEvent<string>[]
+            {
+                StreamEvent.CreateStart(0, "A"),
+                StreamEvent.CreateStart(5, "A"),
+                StreamEvent.CreateStart(6, "AB"),
+                StreamEvent.CreateStart(9, "A"),
+            };
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
     }
 
     [TestClass]


### PR DESCRIPTION
Currently, the Afa Concat logic considers transitions in the patterns being concatenated to the first pattern, but neglects the case where the pattern being concatenated has a final state equal to the start state. In this case, there is not necessarily a transition to that state (that is both the start and a final state), so we must add it explicitly to the concatenation result pattern.