### PR TITLE
Fixing enumerable serialization at batch boundary

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Serializer/Serializers/EnumerableSerializer.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Serializer/Serializers/EnumerableSerializer.cs
@@ -76,7 +76,7 @@ namespace Microsoft.StreamProcessing.Serializer.Serializers
                         Expression.NotEqual(MoveNextExpression.ReplaceParametersInBody(enumerator), Expression.Constant(false)),
                         Expression.Block(
                             Expression.Assign(item, Expression.Property(enumerator, "Current")),
-                            Expression.IfThenElse(
+                            Expression.IfThen(
                                 Expression.Equal(counter, Expression.Constant(1024)),
                                 Expression.Block(
                                     EncodeArrayChunkMethod.ReplaceParametersInBody(encoder, Expression.Constant(1024)),
@@ -87,10 +87,9 @@ namespace Microsoft.StreamProcessing.Serializer.Serializers
                                             Expression.IfThen(Expression.GreaterThanOrEqual(chunkCounter, Expression.Property(buffer, "Count")), Expression.Break(chunkBreak)), this.itemSchema.BuildSerializer(encoder, Expression.Property(buffer, "Item", chunkCounter)),
                                             Expression.PreIncrementAssign(chunkCounter)),
                                             chunkBreak),
-                                    ListClearExpression.ReplaceParametersInBody(buffer)),
-                                Expression.Block(
-                                    ListAddExpression.ReplaceParametersInBody(buffer, item),
-                                    Expression.PreIncrementAssign(counter)))),
+                                    ListClearExpression.ReplaceParametersInBody(buffer))),
+                            ListAddExpression.ReplaceParametersInBody(buffer, item),
+                            Expression.PreIncrementAssign(counter)),
                         Expression.Break(arrayBreak)),
                     arrayBreak),
                 EncodeArrayChunkMethod.ReplaceParametersInBody(encoder, Expression.Property(buffer, "Count")),

--- a/Sources/Test/SimpleTesting/Serializer/EnumerableSerializationTests.cs
+++ b/Sources/Test/SimpleTesting/Serializer/EnumerableSerializationTests.cs
@@ -1,0 +1,100 @@
+﻿// *********************************************************************
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License
+// *********************************************************************
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using Microsoft.StreamProcessing.Serializer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SimpleTesting
+{
+    public class TestEnumerable<T> : IEnumerable<T>
+    {
+        protected readonly List<T> data;
+
+        public TestEnumerable() => this.data = new List<T>();
+
+        public TestEnumerable(IEnumerable<T> data) => this.data = new List<T>(data);
+
+        public void Add(T value) => this.data.Add(value);
+
+        public IEnumerator<T> GetEnumerator() => this.data.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public class TestCollection<T> : TestEnumerable<T>, ICollection<T>
+    {
+        public TestCollection()
+        {
+        }
+
+        public TestCollection(IEnumerable<T> data) : base(data)
+        {
+        }
+
+        public int Count => this.data.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Clear() => this.data.Clear();
+        public bool Contains(T item) => this.data.Contains(item);
+        public void CopyTo(T[] array, int arrayIndex) => this.data.CopyTo(array, arrayIndex);
+        public bool Remove(T item) => this.data.Remove(item);
+    }
+
+    public class TestList<T> : TestCollection<T>, IList<T>
+    {
+        public TestList()
+        {
+        }
+
+        public TestList(IEnumerable<T> data) : base(data)
+        {
+        }
+
+        public T this[int index] { get => this.data[index]; set => this.data[index] = value; }
+
+        public int IndexOf(T item) => this.data.IndexOf(item);
+        public void Insert(int index, T item) => this.data.Insert(index, item);
+        public void RemoveAt(int index) => this.data.RemoveAt(index);
+    }
+
+    [TestClass]
+    public class EnumerableSerializationTests : TestWithConfigSettingsWithoutMemoryLeakDetection
+    {
+        private const int SerializationCount = 10000;
+
+        [TestMethod, TestCategory("Gated")]
+        public void EnumerableSerialization() => TestSerialization(new TestEnumerable<int>(GetTestData()));
+
+        [TestMethod, TestCategory("Gated")]
+        public void CollectionSerialization() => TestSerialization(new TestCollection<int>(GetTestData()));
+
+        [TestMethod, TestCategory("Gated")]
+        public void ListSerialization() => TestSerialization(new TestList<int>(GetTestData()));
+
+        private static void TestSerialization<T>(T enumerable)
+            where T : IEnumerable<int>
+        {
+            var serializer = StreamableSerializer.Create<T>();
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(stream, enumerable);
+                stream.Flush();
+                stream.Seek(0, SeekOrigin.Begin);
+
+                var copy = serializer.Deserialize(stream);
+
+                Assert.IsTrue(enumerable.SequenceEqual(copy));
+            }
+        }
+
+        private List<int> GetTestData() => Enumerable.Range(0, SerializationCount).ToList();
+    }
+}

--- a/Sources/Test/SimpleTesting/SimpleTesting.csproj
+++ b/Sources/Test/SimpleTesting/SimpleTesting.csproj
@@ -57,6 +57,7 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
     </Compile>
+    <Compile Include="Serializer\EnumerableSerializationTests.cs" />
     <Compile Include="Streamables\AfaTests.cs" />
     <Compile Include="Aggregates\AverageAggregate.cs" />
     <Compile Include="Aggregates\CompoundAggregate.cs" />


### PR DESCRIPTION
Trill's serializer uses batches of 1024 to serialize IEnumerables, but there is a bug where we skip serialization of an event at the batch boundary.