### PR TITLE
Fix multi-where clause getting executed, even when first where clause evaluates false

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Aggregates/TumblingMaxAggregate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Aggregates/TumblingMaxAggregate.cs
@@ -35,7 +35,7 @@ namespace Microsoft.StreamProcessing.Aggregates
             var typeInfo = typeof(MinMaxState<T>).GetTypeInfo();
             this.accumulate = Expression.Lambda<Func<MinMaxState<T>, long, T, MinMaxState<T>>>(
                 Expression.Condition(
-                    Expression.Or(
+                    Expression.OrElse(
                         Expression.Equal(currentTimestampExpression, Expression.Constant(InvalidSyncTime)),
                         Expression.GreaterThan(comparerExpression, Expression.Constant(0))),
                     Expression.MemberInit(

--- a/Sources/Core/Microsoft.StreamProcessing/Aggregates/TumblingMinAggregate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Aggregates/TumblingMinAggregate.cs
@@ -35,7 +35,7 @@ namespace Microsoft.StreamProcessing.Aggregates
             var typeInfo = typeof(MinMaxState<T>).GetTypeInfo();
             this.accumulate = Expression.Lambda<Func<MinMaxState<T>, long, T, MinMaxState<T>>>(
                 Expression.Condition(
-                    Expression.Or(
+                    Expression.OrElse(
                         Expression.Equal(currentTimestampExpression, Expression.Constant(InvalidSyncTime)),
                         Expression.LessThan(comparerExpression, Expression.Constant(0))),
                     Expression.MemberInit(

--- a/Sources/Core/Microsoft.StreamProcessing/Fusible/FuseModule.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Fusible/FuseModule.cs
@@ -486,7 +486,7 @@ namespace Microsoft.StreamProcessing
             var prev = this.expressions[this.expressions.Count - 1];
             var parameter = prev.expression.Parameters[0];
             var replaced = expression.ReplaceParametersInBody(parameter);
-            prev.expression = Expression.Lambda<Func<TPayload, bool>>(Expression.And(prev.expression.Body, replaced), parameter);
+            prev.expression = Expression.Lambda<Func<TPayload, bool>>(Expression.AndAlso(prev.expression.Body, replaced), parameter);
             return this;
         }
 

--- a/Sources/Test/SimpleTesting/SimpleTesting.csproj
+++ b/Sources/Test/SimpleTesting/SimpleTesting.csproj
@@ -167,6 +167,7 @@
       <DependentUpon>SnapshotTests.tt</DependentUpon>
     </Compile>
     <Compile Include="Streamables\StitchTest.cs" />
+    <Compile Include="Streamables\WhereTest.cs" />
     <Compile Include="Serializer\SurrogateTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Sources/Test/SimpleTesting/Streamables/WhereTest.cs
+++ b/Sources/Test/SimpleTesting/Streamables/WhereTest.cs
@@ -1,0 +1,35 @@
+﻿using System.Reactive.Linq;
+using Microsoft.StreamProcessing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SimpleTesting.NewTest
+{
+    [TestClass]
+    public class WhereTest : TestWithConfigSettingsAndMemoryLeakDetection
+    {
+        [TestMethod, TestCategory("Gated")]
+        public void WhereClauseDoesNotProcessSubsequentExpressions()
+        {
+            var data = new StreamEvent<string>[]
+            {
+                StreamEvent.CreateInterval(0, 100, "1"),
+                StreamEvent.CreateInterval(1, 100, "2"),
+                StreamEvent.CreateInterval(2, 100, "NA"),
+                StreamEvent.CreateInterval(3, 100, "3"),
+            }.ToObservable()
+             .ToStreamable();
+
+            var result = data.Where(x => x != "NA") // First, filter out invalid values
+                             .Where(x => int.Parse(x) > 1); // Then, work with valid ints
+
+            var expected = new StreamEvent<string>[]
+            {
+                StreamEvent.CreateInterval(1, 100, "2"),
+                StreamEvent.CreateInterval(3, 100, "3"),
+                StreamEvent.CreatePunctuation<string>(StreamEvent.InfinitySyncTime)
+            };
+
+            Assert.IsTrue(result.IsEquivalentTo(expected));
+        }
+    }
+}


### PR DESCRIPTION
Fix multi-where clause getting executed during filtering, by using conditional AND/OR operators instead of bitwise AND/OR.

Example:
```
var data = new [] { "1", "NA", "2" } ;
var result = data.Where(x => x != "NA") // First, filter out invalid values
                 .Where(x => int.Parse(x) > 1); // Then, work with valid ints
```
This cause an exception as int.Parse is called on "NA" string.

Another case:
```
var data = new [] { 1, 0, 2, 3 };
var result = data.Where(x => x != 0) // First, filter out zeros
                 .Where(10/x  > 4); // Then, work with valid
```
results in divide by zero exception