### PR TITLE
Fixing DisjointUnion bug resulting in negative low watermark

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/DisjointUnion/DisjointUnionPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/DisjointUnion/DisjointUnionPipe.cs
@@ -15,9 +15,9 @@ namespace Microsoft.StreamProcessing
         private readonly MemoryPool<TKey, TPayload> pool;
 
         [DataMember]
-        private long leftGlobalPunctuation = long.MinValue;
+        private long leftGlobalPunctuation = 0;
         [DataMember]
-        private long rightGlobalPunctuation = long.MinValue;
+        private long rightGlobalPunctuation = 0;
 
         [Obsolete("Used only by serialization. Do not call directly.")]
         public DisjointUnionPipe() { }


### PR DESCRIPTION
DisjointUnion initializes its low watermarks for left/right side of the union to long.MinValue, but when searching a batch for a low watermark, it initializes the value to -1 which signifies no low watermark present. So if the first batch it receives does not have a low watermark, and one of the sides has not yet processed a valid low watermark, it will compare the "new low watermark" of -1 to the initialized long.MinValue, and wrongfully emit a low watermark of -1. The fix is to initialize the low watermarks for each side to 0, since we should never emit a low watermark <= 0.