### PR TITLE
Jonathan keaveney

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -51,3 +51,16 @@ csharp_new_line_before_finally = true
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_preserve_single_line_statements = false
+[*.{cs,vb}]
+
+# IDE0003: Remove qualification
+dotnet_style_qualification_for_event = false:none
+
+# IDE0003: Remove qualification
+dotnet_style_qualification_for_field = false:none
+
+# IDE0003: Remove qualification
+dotnet_style_qualification_for_property = false:none
+
+# IDE0003: Remove qualification
+dotnet_style_qualification_for_method = false:none

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -51,16 +51,3 @@ csharp_new_line_before_finally = true
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_preserve_single_line_statements = false
-[*.{cs,vb}]
-
-# IDE0003: Remove qualification
-dotnet_style_qualification_for_event = false:none
-
-# IDE0003: Remove qualification
-dotnet_style_qualification_for_field = false:none
-
-# IDE0003: Remove qualification
-dotnet_style_qualification_for_property = false:none
-
-# IDE0003: Remove qualification
-dotnet_style_qualification_for_method = false:none

--- a/Sources/Core/Microsoft.StreamProcessing/Utilities/ComparerExpression.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Utilities/ComparerExpression.cs
@@ -39,7 +39,7 @@ namespace Microsoft.StreamProcessing
             typeComparerCache.Add(typeof(uint), new PrimitiveComparerExpression<uint>((x, y) => x < y ? -1 : x == y ? 0 : 1));
             typeComparerCache.Add(typeof(long), new PrimitiveComparerExpression<long>((x, y) => x < y ? -1 : x == y ? 0 : 1));
             typeComparerCache.Add(typeof(ulong), new PrimitiveComparerExpression<ulong>((x, y) => x < y ? -1 : x == y ? 0 : 1));
-            typeComparerCache.Add(typeof(decimal), new PrimitiveComparerExpression<ulong>((x, y) => x < y ? -1 : x == y ? 0 : 1));
+            typeComparerCache.Add(typeof(decimal), new PrimitiveComparerExpression<decimal>((x, y) => x < y ? -1 : x == y ? 0 : 1));
             typeComparerCache.Add(typeof(string), new GenericComparableExpression<string>());
             typeComparerCache.Add(typeof(TimeSpan), new GenericComparableExpression<TimeSpan>());
             typeComparerCache.Add(typeof(DateTime), new GenericComparableExpression<DateTime>());

--- a/Sources/Core/Microsoft.StreamProcessing/Utilities/ComparerExpression.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Utilities/ComparerExpression.cs
@@ -39,7 +39,7 @@ namespace Microsoft.StreamProcessing
             typeComparerCache.Add(typeof(uint), new PrimitiveComparerExpression<uint>((x, y) => x < y ? -1 : x == y ? 0 : 1));
             typeComparerCache.Add(typeof(long), new PrimitiveComparerExpression<long>((x, y) => x < y ? -1 : x == y ? 0 : 1));
             typeComparerCache.Add(typeof(ulong), new PrimitiveComparerExpression<ulong>((x, y) => x < y ? -1 : x == y ? 0 : 1));
-            typeComparerCache.Add(typeof(decimal), new PrimitiveComparerExpression<decimal>((x, y) => x < y ? -1 : x == y ? 0 : 1));
+            typeComparerCache.Add(typeof(decimal), new PrimitiveComparerExpression<ulong>((x, y) => x < y ? -1 : x == y ? 0 : 1));
             typeComparerCache.Add(typeof(string), new GenericComparableExpression<string>());
             typeComparerCache.Add(typeof(TimeSpan), new GenericComparableExpression<TimeSpan>());
             typeComparerCache.Add(typeof(DateTime), new GenericComparableExpression<DateTime>());


### PR DESCRIPTION
Hi

If I run the following code

`
SensorReading[] historicData = new[]
{
	new SensorReading { Time = 1, Value = (decimal)0.33 },
	new SensorReading { Time = 2, Value = 20 },
	new SensorReading { Time = 3, Value = 15 },
	new SensorReading { Time = 4, Value = 30 },
	new SensorReading { Time = 5, Value = 45 }, // Here we crossed the threshold upward
	new SensorReading { Time = 6, Value = 50 },
	new SensorReading { Time = 7, Value = 30 }, // Here we crossed downward. Note that the current query logic only detects upward swings.
	new SensorReading { Time = 8, Value = 35 },
	new SensorReading { Time = 9, Value = 60 }, // Here we crossed upward again
	new SensorReading { Time = 10, Value = 20 }
};
var streamable1 = historicData
	.ToObservable().ToTemporalStreamable(r => r.Time, r => r.Time + 10);

var output = streamable1.TumblingWindowLifetime(3)
	   .Aggregate(
	   w => w.Max(x => x.Value),
	   w => w.Min(v => v.Value),
	   (max, min) => new { Max = max, Min = min });
`
I get this error
System.InvalidCastException
  HResult=0x80004002
  Message=Unable to cast object of type 'Microsoft.StreamProcessing.PrimitiveComparerExpression`1[System.UInt64]' to type 'Microsoft.StreamProcessing.IComparerExpression`1[System.Decimal]'.
  Source=Microsoft.StreamProcessing
  StackTrace:
   at Microsoft.StreamProcessing.ComparerExpressionCache.TryGetCachedComparer[T](IComparerExpression`1& comparer) in C:\Users\jonathan.keaveney\githubrepo\Trill\Sources\Core\Microsoft.StreamProcessing\Utilities\ComparerExpression.cs:line 56
   at Microsoft.StreamProcessing.ComparerExpression`1.get_Default() in C:\Users\jonathan.keaveney\githubrepo\Trill\Sources\Core\Microsoft.StreamProcessing\Utilities\ComparerExpression.cs:line 80
   at Microsoft.StreamProcessing.Aggregates.TumblingMaxAggregate`1..ctor() in C:\Users\jonathan.keaveney\githubrepo\Trill\Sources\Core\Microsoft.StreamProcessing\Aggregates\TumblingMaxAggregate.cs:line 18
   at Microsoft.StreamProcessing.Window`2.Max[TValue](Expression`1 selector) in C:\Users\jonathan.keaveney\githubrepo\Trill\Sources\Core\Microsoft.StreamProcessing\Windows\Window.cs:line 130
   at MyExample.Program.<>c.<Main>b__4_2(Window`2 w) in C:\Users\jonathan.keaveney\Documents\TrillSamples-master\TrillSamples-master\TrillSamples\MyExample\Program.cs:line 125
   at Microsoft.StreamProcessing.Streamable.Aggregate[TKey,TInput,TState1,TOutput1,TState2,TOutput2,TOutput](IStreamable`2 source, Func`2 aggregate1, Func`2 aggregate2, Expression`1 merger) in C:\Users\jonathan.keaveney\githubrepo\Trill\Sources\Core\Microsoft.StreamProcessing\StreamableAPI\StreamableExtensionsTemplate.cs:line 2085
   at MyExample.Program.Main(String[] args) in C:\Users\jonathan.keaveney\Documents\TrillSamples-master\TrillSamples-master\TrillSamples\MyExample\Program.cs:line 123

I had to make a small change to the ComparerExpressionCache() to resolve.

Cheers, Jonathan