### PR TITLE
Fix Roslyn Breaking Change

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledAfa.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledAfa.cs
@@ -164,9 +164,7 @@ namespace Microsoft.StreamProcessing
                                         toState = to,
                                         Initialize = mearc.Initialize != null
                                             ? mearc.Initialize.Compile()
-                                            : this.defaultAccumulator == default
-                                                ? (ts, reg) => default // To avoid a closure
-                                                : (Func<long, TRegister, TAccumulator>)((ts, reg) => this.defaultAccumulator),
+                                            : (ts, reg) => this.defaultAccumulator,
                                         Accumulate = mearc.Accumulate != null ? mearc.Accumulate.Compile() : (ts, ev, reg, acc) => acc,
                                         SkipToEnd = mearc.SkipToEnd?.Compile(),
                                         Dispose = mearc.Dispose?.Compile(),


### PR DESCRIPTION
Our code currently uses == to compare an instance of an unconstrained generic type to "default", which used to compile to the equivalent of "== default(object)", but this does not work as intended for value types and is now disallowed by Roslyn (see breaking change, https://github.com/dotnet/roslyn/blob/master/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20post%20VS2019.md):

> https://github.com/dotnet/roslyn/issues/35684 In C# 7.1 the resolution of a binary operator with a default literal and unconstrained type parameter could result in using an object equality and giving the literal a type object. For example, given a variable t of an unconstrained type T, t == default would be improperly allowed and emitted as t == default(object). In Visual Studio 2019 version 16.4 this scenario will now produce an error.

Since this comparison is only used as a slight optimization to avoid a closure, I am simply removing that optimization for now.