### PR TITLE
Fix zero or one when pattern contains loop back to start

### DIFF
--- a/Sources/Test/SimpleTesting/Streamables/AfaTests.cs
+++ b/Sources/Test/SimpleTesting/Streamables/AfaTests.cs
@@ -683,6 +683,54 @@ namespace SimpleTesting
                 longPool.Free();
             }
         }
+
+        [TestMethod, TestCategory("Gated")]
+        public void AfaZeroOrOneGroup()
+        {
+            var source = new StreamEvent<string>[]
+            {
+                StreamEvent.CreateStart(0, "O"),
+                StreamEvent.CreateStart(1, "A"),
+                StreamEvent.CreateStart(2, "A"),
+                StreamEvent.CreateStart(3, "F"),
+                StreamEvent.CreateStart(4, "O"),
+            }.ToObservable()
+                .ToStreamable()
+                .AlterEventDuration(10);
+
+            // O(A*F)?
+            var afa = ARegex.Concat(
+                        ARegex.SingleElement<string, string>(
+                            (time, @event, state) => @event == "O",
+                            (time, @event, state) => state + @event),
+                        ARegex.ZeroOrOne(
+                            ARegex.Concat(
+                                ARegex.KleeneStar(
+                                    ARegex.SingleElement<string, string>(
+                                        (time, @event, state) => @event == "A",
+                                        (time, @event, state) => state + @event)),
+                                ARegex.SingleElement<string, string>(
+                                    (time, @event, state) => @event == "F",
+                                    (time, @event, state) => state + @event))));
+
+            var result = source
+                .Detect(
+                    afa,
+                    allowOverlappingInstances: false,
+                    isDeterministic: false)
+                .ToStreamEventObservable()
+                .Where(evt => evt.IsData)
+                .ToEnumerable()
+                .ToArray();
+            var expected = new StreamEvent<string>[]
+            {
+                StreamEvent.CreateInterval(0, 10, "O"),
+                StreamEvent.CreateInterval(3, 10, "OAAF"),
+                StreamEvent.CreateInterval(4, 14, "O"),
+            };
+
+            Assert.IsTrue(result.SequenceEqual(expected));
+        }
     }
 
     /// <summary>
@@ -723,7 +771,8 @@ namespace SimpleTesting
                     (time, @event, state) => state + @event));
 
             var afa_compiled = source
-                .Detect(afa);
+                .Detect(
+                    afa);
             afa_compiled.Properties.IsSyncTimeSimultaneityFree = true;
 
             var result = afa_compiled
@@ -770,7 +819,8 @@ namespace SimpleTesting
                         (time, @event, state) => state + @event)));
 
             var afa_compiled = source
-                .Detect(afa);
+                .Detect(
+                    afa);
             afa_compiled.Properties.IsSyncTimeSimultaneityFree = true;
 
             var result = afa_compiled
@@ -877,11 +927,11 @@ namespace SimpleTesting
             var afa_compiled = source.GroupApply(
                 (input) => input.Item2,
                 group =>
-                {
-                    var afaGroup = group.Detect(afa, maxDuration: 10);
-                    afaGroup.Properties.IsSyncTimeSimultaneityFree = true;
-                    return afaGroup;
-                },
+                    {
+                        var afaGroup = group.Detect(afa, maxDuration: 10);
+                        afaGroup.Properties.IsSyncTimeSimultaneityFree = true;
+                        return afaGroup;
+                    },
                 (group, bind) => bind);
 
             var result = afa_compiled
@@ -999,7 +1049,9 @@ namespace SimpleTesting
                                 (time, @event, state) => state + @event));
 
             var afa_compiled = source
-                .Detect(afa, maxDuration: 7);
+                .Detect(
+                    afa,
+                    maxDuration: 7);
 
             afa_compiled.Properties.IsSyncTimeSimultaneityFree = true;
 
@@ -1045,7 +1097,9 @@ namespace SimpleTesting
                                     (time, @event, state) => state + @event)));
 
             var result = source
-                .Detect(afa, maxDuration: 4)
+                .Detect(
+                    afa,
+                    maxDuration: 4)
                 .ToStreamEventObservable()
                 .Where(evt => evt.IsData)
                 .ToEnumerable()
@@ -1089,7 +1143,9 @@ namespace SimpleTesting
                                     (time, @event, state) => state + @event)));
 
             var result = source
-                .Detect(afa, maxDuration: 7)
+                .Detect(
+                    afa,
+                    maxDuration: 7)
                 .ToStreamEventObservable()
                 .Where(evt => evt.IsData)
                 .ToEnumerable()
@@ -1102,65 +1158,6 @@ namespace SimpleTesting
                 PartitionedStreamEvent.CreateInterval(1, 5, 7, "ABBBB"),
                 PartitionedStreamEvent.CreateInterval(1, 12, 18, "AB"),
                 PartitionedStreamEvent.CreateInterval(1, 13, 18, "ABB"),
-            };
-            Assert.IsTrue(result.SequenceEqual(expected));
-        }
-
-        internal class State
-        {
-            // This cannot be an enum because we want represent a concatinated state in terms of digits in int value
-            public const int A = 1;
-            public const int B = 2;
-            public const int C = 3;
-        }
-
-        [TestMethod, TestCategory("Gated")]
-        public void AfaZeroOrOneWithStartEvent()
-        {
-            var source = new StreamEvent<int>[]
-            {
-                StreamEvent.CreateStart(0, State.A),
-                StreamEvent.CreateStart(1, State.C),
-                StreamEvent.CreateStart(2, State.B),
-                StreamEvent.CreateStart(3, State.B),
-                StreamEvent.CreateStart(4, State.C),
-                StreamEvent.CreateStart(5, State.A),
-                StreamEvent.CreateStart(6, State.B),
-                StreamEvent.CreateStart(7, State.B),
-                StreamEvent.CreateStart(8, State.B),
-                StreamEvent.CreateStart(9, State.A),
-            }.ToObservable()
-                .ToStreamable()
-                .SetProperty().IsConstantDuration(true, StreamEvent.InfinitySyncTime);
-
-            // Assert we are actually testing columnar
-            Assert.IsTrue(source.Properties.IsColumnar);
-
-            var afa = ARegex.Concat(
-                ARegex.SingleElement<int, int>(
-                    (time, @event, state) => @event == State.A,
-                    (time, @event, state) => @event),
-                ARegex.ZeroOrOne(
-                    ARegex.SingleElement<int, int>(
-                        (time, @event, state) => @event == State.B,
-                        (time, @event, state) => state * 10 + @event)));
-
-            var result = source
-                .Detect(
-                    afa,
-                    allowOverlappingInstances: false,
-                    isDeterministic: false)
-                .ToStreamEventObservable()
-                .Where(evt => evt.IsData)
-                .ToEnumerable()
-                .ToArray();
-
-            var expected = new StreamEvent<int>[]
-            {
-                StreamEvent.CreateStart(0, State.A),
-                StreamEvent.CreateStart(5, State.A),
-                StreamEvent.CreateStart(6, State.A * 10 + State.B),
-                StreamEvent.CreateStart(9, State.A),
             };
             Assert.IsTrue(result.SequenceEqual(expected));
         }


### PR DESCRIPTION
Currently, the Regex ZeroOrOne operator works by modifying the pattern's state machine to add its start state as another final state. This immediate final state covers the "zero" case. However, when the pattern's state machine has the potential to loop back to its start state, this can result in producing multiple matches solely for the "zero" case, which is incorrect.
To fix this, ZeroOrOne will now detect when the pattern contains a loop back to start, and in this case, prepend a simple epsilon arc to the pattern, setting the starting state as zero, guaranteeing there is no loop back to this new start state.
Taking the added test case in this PR as an example, consider the pattern "(A*F)", which results in a state machine of:
```
             "A"
           <----
(start) 0         1  ----> 2 (final)
           ---->      "F"
          epsilon
```
           
Before this fix, wrapping this pattern using a ZeroOrOne operator, i.e. "(A*F)?", simply marked the starting state as final, resulted in a state machine of:
```
                   "A"
                  <----
(start, final) 0         1  ----> 2 (final)
                  ---->       "F"
                 epsilon
```
E.g., with an input pattern of "OAAFO", this would result in matches at index 0 (correct), 1 (incorrect), 2 (incorrect), 3 (correct), and 4 (correct).
With this fix, ZeroOrOne will detect these loops, and instead prepend an epsilon arc before the pattern, producing the correct output:
```
                             "A"
                            <----
(start, final ) 0  ----> 1         2  ----> 3 (final)
                  epsilon   ---->       "F"
                           epsilon
```