### PR TITLE
Do not insert into a FastMap while traversing that FastMap

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/AfaMultiEventListTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/AfaMultiEventListTemplate.tt
@@ -188,6 +188,8 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
 
 <# if (grouped) { #>
 
+                // Track which active states need to be inserted after the current traversal
+                var newActiveStates = new List<GroupedActiveState<<#= TKey #>, <#= TRegister #>>>();
                 while (activeFindTraverser.Next(out index))
 <# } else { #>
             if (activeStatesTraverser.Find())
@@ -196,10 +198,9 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
 <# } #>
                 {
                     orig_index = index;
-
+                    
                     var state = activeStates.Values[index];
 <# if (grouped) { #>
-
                     if (!(<#= keyEqualityComparer("state.key", "currentList.key") #>)) continue;
 <# } #>
 
@@ -268,17 +269,39 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
                                     <# if (hasOutgoingArcs[ns]) { #>
 
                                     {
-                                        // target node has outgoing edges
-                                        if (index == -1) index = activeStates.Insert(<#= grouped ? "el_hash" : string.Empty #>);
 <# if (grouped) { #>
+                                        // target node has outgoing edges
+                                        // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                        // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                        if (index != -1)
+                                        {
+                                            activeStates.Values[index].key = currentList.key;
+                                            activeStates.Values[index].state = <#= ns #>;
+                                            activeStates.Values[index].register = newReg;
+                                            activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                        activeStates.Values[index].key = currentList.key;
-<# } #>
+                                            index = -1;
+                                        }
+                                        else
+                                        {
+                                            // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                            newActiveStates.Add(new GroupedActiveState<<#= TKey #>, <#= TRegister #>>
+                                            {
+                                                key = currentList.key,
+                                                state = <#= ns #>,
+                                                register = newReg,
+                                                PatternStartTimestamp = state.PatternStartTimestamp,
+                                            });
+                                        }
+<# } else { #>
+                                        // target node has outgoing edges
+                                        if (index == -1) index = activeStates.Insert();
                                         activeStates.Values[index].state = <#= ns #>;
                                         activeStates.Values[index].register = newReg;
                                         activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
                                         index = -1;
+<# } #>
 
                                         ended = false;
                                     }
@@ -316,6 +339,13 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
                 }
 <# if (!grouped) { #>
              }
+<# } else { #>
+
+                // Now that we are done traversing the current active states, add any new ones.
+                foreach (var newActiveState in newActiveStates)
+                {
+                    this.activeStates.Insert(el_hash, newActiveState);
+                }
 <# } #>
             }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_MultiEventList.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_MultiEventList.cs
@@ -66,6 +66,8 @@ namespace Microsoft.StreamProcessing
                 {
                     int orig_index;
 
+                    // Track which active states need to be inserted after the current traversal
+                    var newActiveStates = new List<GroupedActiveState<TKey, TRegister>>();
                     while (this.activeFindTraverser.Next(out int index))
                     {
                         orig_index = index;
@@ -116,13 +118,28 @@ namespace Microsoft.StreamProcessing
 
                                                 if (this.hasOutgoingArcs[ns])
                                                 {
-                                                    if (index == -1) index = this.activeStates.Insert(el_hash);
-                                                    this.activeStates.Values[index].key = currentList.key;
-                                                    this.activeStates.Values[index].state = ns;
-                                                    this.activeStates.Values[index].register = newReg;
-                                                    this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                    if (index != -1)
+                                                    {
+                                                        this.activeStates.Values[index].key = currentList.key;
+                                                        this.activeStates.Values[index].state = ns;
+                                                        this.activeStates.Values[index].register = newReg;
+                                                        this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                    index = -1;
+                                                        index = -1;
+                                                    }
+                                                    else
+                                                    {
+                                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                        newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                        {
+                                                            key = currentList.key,
+                                                            state = ns,
+                                                            register = newReg,
+                                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                                        });
+                                                    }
 
                                                     ended = false;
 
@@ -178,13 +195,29 @@ namespace Microsoft.StreamProcessing
 
                                                 if (this.hasOutgoingArcs[ns])
                                                 {
-                                                    if (index == -1) index = this.activeStates.Insert(el_hash);
-                                                    this.activeStates.Values[index].key = currentList.key;
-                                                    this.activeStates.Values[index].state = ns;
-                                                    this.activeStates.Values[index].register = newReg;
-                                                    this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                    if (index != -1)
+                                                    {
+                                                        if (index == -1) index = this.activeStates.Insert(el_hash);
+                                                        this.activeStates.Values[index].key = currentList.key;
+                                                        this.activeStates.Values[index].state = ns;
+                                                        this.activeStates.Values[index].register = newReg;
+                                                        this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                    index = -1;
+                                                        index = -1;
+                                                    }
+                                                    else
+                                                    {
+                                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                        newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                        {
+                                                            key = currentList.key,
+                                                            state = ns,
+                                                            register = newReg,
+                                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                                        });
+                                                    }
 
                                                     ended = false;
 
@@ -248,13 +281,28 @@ namespace Microsoft.StreamProcessing
 
                                                 if (this.hasOutgoingArcs[ns])
                                                 {
-                                                    if (index == -1) index = this.activeStates.Insert(el_hash);
-                                                    this.activeStates.Values[index].key = currentList.key;
-                                                    this.activeStates.Values[index].state = ns;
-                                                    this.activeStates.Values[index].register = newReg;
-                                                    this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                    if (index != -1)
+                                                    {
+                                                        this.activeStates.Values[index].key = currentList.key;
+                                                        this.activeStates.Values[index].state = ns;
+                                                        this.activeStates.Values[index].register = newReg;
+                                                        this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                    index = -1;
+                                                        index = -1;
+                                                    }
+                                                    else
+                                                    {
+                                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                        newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                        {
+                                                            key = currentList.key,
+                                                            state = ns,
+                                                            register = newReg,
+                                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                                        });
+                                                    }
 
                                                     ended = false;
 
@@ -277,6 +325,12 @@ namespace Microsoft.StreamProcessing
                         }
                         if (index == orig_index) this.activeFindTraverser.Remove();
                         if (this.IsDeterministic) break; // We are guaranteed to have only one active state
+                    }
+
+                    // Now that we are done traversing the current active states, add any new ones.
+                    foreach (var newActiveState in newActiveStates)
+                    {
+                        this.activeStates.Insert(el_hash, newActiveState);
                     }
                 }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_SingleEvent.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledGroupedAfaPipe_SingleEvent.cs
@@ -153,6 +153,8 @@ namespace Microsoft.StreamProcessing
                             {
                                 int orig_index;
 
+                                // Track which active states need to be inserted after the current traversal
+                                var newActiveStates = new List<GroupedActiveState<TKey, TRegister>>();
                                 while (activeFindTraverser.Next(out int index))
                                 {
                                     orig_index = index;
@@ -211,13 +213,28 @@ namespace Microsoft.StreamProcessing
 
                                                         if (this.hasOutgoingArcs[ns])
                                                         {
-                                                            if (index == -1) index = this.activeStates.Insert(src_hash[i]);
-                                                            this.activeStates.Values[index].key = srckey[i];
-                                                            this.activeStates.Values[index].state = ns;
-                                                            this.activeStates.Values[index].register = newReg;
-                                                            this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                            // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                            // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                            if (index != -1)
+                                                            {
+                                                                this.activeStates.Values[index].key = srckey[i];
+                                                                this.activeStates.Values[index].state = ns;
+                                                                this.activeStates.Values[index].register = newReg;
+                                                                this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                            index = -1;
+                                                                index = -1;
+                                                            }
+                                                            else
+                                                            {
+                                                                // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                                newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                                {
+                                                                    key = srckey[i],
+                                                                    state = ns,
+                                                                    register = newReg,
+                                                                    PatternStartTimestamp = state.PatternStartTimestamp,
+                                                                });
+                                                            }
 
                                                             ended = false;
 
@@ -239,6 +256,12 @@ namespace Microsoft.StreamProcessing
                                     }
                                     if (index == orig_index) activeFindTraverser.Remove();
                                     if (this.IsDeterministic) break; // We are guaranteed to have only one active state
+                                }
+
+                                // Now that we are done traversing the current active states, add any new ones.
+                                foreach (var newActiveState in newActiveStates)
+                                {
+                                    this.activeStates.Insert(src_hash[i], newActiveState);
                                 }
                             }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_EventList.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_EventList.cs
@@ -62,6 +62,8 @@ namespace Microsoft.StreamProcessing
                 {
                     int orig_index;
 
+                    // Track which active states need to be inserted after the current traversal
+                    var newActiveStates = new List<GroupedActiveState<TKey, TRegister>>();
                     while (this.activeFindTraverser.Next(out int index))
                     {
                         orig_index = index;
@@ -104,13 +106,28 @@ namespace Microsoft.StreamProcessing
 
                                                 if (this.hasOutgoingArcs[ns])
                                                 {
-                                                    if (index == -1) index = this.activeStates.Insert(el_hash);
-                                                    this.activeStates.Values[index].key = currentList.key;
-                                                    this.activeStates.Values[index].state = ns;
-                                                    this.activeStates.Values[index].register = newReg;
-                                                    this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                    if (index != -1)
+                                                    {
+                                                        this.activeStates.Values[index].key = currentList.key;
+                                                        this.activeStates.Values[index].state = ns;
+                                                        this.activeStates.Values[index].register = newReg;
+                                                        this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                    index = -1;
+                                                        index = -1;
+                                                    }
+                                                    else
+                                                    {
+                                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                        newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                        {
+                                                            key = currentList.key,
+                                                            state = ns,
+                                                            register = newReg,
+                                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                                        });
+                                                    }
 
                                                     ended = false;
 
@@ -164,13 +181,28 @@ namespace Microsoft.StreamProcessing
 
                                                 if (this.hasOutgoingArcs[ns])
                                                 {
-                                                    if (index == -1) index = this.activeStates.Insert(el_hash);
-                                                    this.activeStates.Values[index].key = currentList.key;
-                                                    this.activeStates.Values[index].state = ns;
-                                                    this.activeStates.Values[index].register = newReg;
-                                                    this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                    if (index != -1)
+                                                    {
+                                                        this.activeStates.Values[index].key = currentList.key;
+                                                        this.activeStates.Values[index].state = ns;
+                                                        this.activeStates.Values[index].register = newReg;
+                                                        this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                    index = -1;
+                                                        index = -1;
+                                                    }
+                                                    else
+                                                    {
+                                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                        newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                        {
+                                                            key = currentList.key,
+                                                            state = ns,
+                                                            register = newReg,
+                                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                                        });
+                                                    }
 
                                                     ended = false;
 
@@ -193,6 +225,12 @@ namespace Microsoft.StreamProcessing
                         }
                         if (index == orig_index) this.activeFindTraverser.Remove();
                         if (this.IsDeterministic) break; // We are guaranteed to have only one active state
+                    }
+
+                    // Now that we are done traversing the current active states, add any new ones.
+                    foreach (var newActiveState in newActiveStates)
+                    {
+                        this.activeStates.Insert(el_hash, newActiveState);
                     }
                 }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_MultiEvent.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_MultiEvent.cs
@@ -141,6 +141,8 @@ namespace Microsoft.StreamProcessing
                                 // Apply new transitions, update existing transitions
                                 bool found = this.activeFindTraverser.Find(src_hash[i]);
 
+                                // Track which active states need to be inserted after the current traversal
+                                var newActiveStates = new List<GroupedActiveStateAccumulator<TKey, TPayload, TRegister, TAccumulator>>();
                                 if (found)
                                 {
                                     while (this.activeFindTraverser.Next(out int activeFind_index))
@@ -158,17 +160,35 @@ namespace Microsoft.StreamProcessing
                                                 for (int cnt = 0; cnt < m; cnt++)
                                                 {
                                                     var arcinfo = currentStateMap[cnt];
+                                                    var accumulator = arcinfo.Initialize(synctime, state.register);
 
-                                                    if (activeFind_index == -1) activeFind_index = this.activeStates.Insert(src_hash[i]);
-                                                    this.activeStates.Values[activeFind_index].arcinfo = arcinfo;
-                                                    this.activeStates.Values[activeFind_index].key = state.key;
-                                                    this.activeStates.Values[activeFind_index].fromState = state.toState;
-                                                    this.activeStates.Values[activeFind_index].toState = arcinfo.toState;
-                                                    this.activeStates.Values[activeFind_index].PatternStartTimestamp = state.PatternStartTimestamp;
-                                                    this.activeStates.Values[activeFind_index].register = state.register;
-                                                    this.activeStates.Values[activeFind_index].accumulator = arcinfo.Initialize(synctime, state.register);
-                                                    this.activeStates.Values[activeFind_index].accumulator = arcinfo.Accumulate(synctime, batch.payload.col[i], state.register, this.activeStates.Values[activeFind_index].accumulator);
-                                                    activeFind_index = -1;
+                                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                    if (activeFind_index != -1)
+                                                    {
+                                                        this.activeStates.Values[activeFind_index].arcinfo = arcinfo;
+                                                        this.activeStates.Values[activeFind_index].key = state.key;
+                                                        this.activeStates.Values[activeFind_index].fromState = state.toState;
+                                                        this.activeStates.Values[activeFind_index].toState = arcinfo.toState;
+                                                        this.activeStates.Values[activeFind_index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                        this.activeStates.Values[activeFind_index].register = state.register;
+                                                        this.activeStates.Values[activeFind_index].accumulator = arcinfo.Accumulate(synctime, batch.payload.col[i], state.register, accumulator);
+                                                        activeFind_index = -1;
+                                                    }
+                                                    else
+                                                    {
+                                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                        newActiveStates.Add(new GroupedActiveStateAccumulator<TKey, TPayload, TRegister, TAccumulator>
+                                                        {
+                                                            arcinfo = arcinfo,
+                                                            key = state.key,
+                                                            fromState = state.toState,
+                                                            toState = arcinfo.toState,
+                                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                                            register = state.register,
+                                                            accumulator = arcinfo.Accumulate(synctime, batch.payload.col[i], state.register, accumulator),
+                                                        });
+                                                    }
                                                 }
                                             }
                                         }
@@ -176,6 +196,12 @@ namespace Microsoft.StreamProcessing
                                         // Remove current state
                                         if (activeFind_index != -1) this.activeFindTraverser.Remove();
                                     }
+                                }
+
+                                // Now that we are done traversing the current active states, add any new ones.
+                                foreach (var newActiveState in newActiveStates)
+                                {
+                                    this.activeStates.Insert(src_hash[i], newActiveState);
                                 }
 
                                 // Insert & accumulate new tentative transitions from start state

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_MultiEventList.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_MultiEventList.cs
@@ -63,6 +63,8 @@ namespace Microsoft.StreamProcessing
                 {
                     int orig_index;
 
+                    // Track which active states need to be inserted after the current traversal
+                    var newActiveStates = new List<GroupedActiveState<TKey, TRegister>>();
                     while (this.activeFindTraverser.Next(out int index))
                     {
                         orig_index = index;
@@ -113,13 +115,28 @@ namespace Microsoft.StreamProcessing
 
                                                 if (this.hasOutgoingArcs[ns])
                                                 {
-                                                    if (index == -1) index = this.activeStates.Insert(el_hash);
-                                                    this.activeStates.Values[index].key = currentList.key;
-                                                    this.activeStates.Values[index].state = ns;
-                                                    this.activeStates.Values[index].register = newReg;
-                                                    this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                    if (index != -1)
+                                                    {
+                                                        this.activeStates.Values[index].key = currentList.key;
+                                                        this.activeStates.Values[index].state = ns;
+                                                        this.activeStates.Values[index].register = newReg;
+                                                        this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                    index = -1;
+                                                        index = -1;
+                                                    }
+                                                    else
+                                                    {
+                                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                        newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                        {
+                                                            key = currentList.key,
+                                                            state = ns,
+                                                            register = newReg,
+                                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                                        });
+                                                    }
 
                                                     ended = false;
 
@@ -175,13 +192,28 @@ namespace Microsoft.StreamProcessing
 
                                                 if (this.hasOutgoingArcs[ns])
                                                 {
-                                                    if (index == -1) index = this.activeStates.Insert(el_hash);
-                                                    this.activeStates.Values[index].key = currentList.key;
-                                                    this.activeStates.Values[index].state = ns;
-                                                    this.activeStates.Values[index].register = newReg;
-                                                    this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                    if (index != -1)
+                                                    {
+                                                        this.activeStates.Values[index].key = currentList.key;
+                                                        this.activeStates.Values[index].state = ns;
+                                                        this.activeStates.Values[index].register = newReg;
+                                                        this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                    index = -1;
+                                                        index = -1;
+                                                    }
+                                                    else
+                                                    {
+                                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                        newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                        {
+                                                            key = currentList.key,
+                                                            state = ns,
+                                                            register = newReg,
+                                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                                        });
+                                                    }
 
                                                     ended = false;
 
@@ -245,13 +277,28 @@ namespace Microsoft.StreamProcessing
 
                                                 if (this.hasOutgoingArcs[ns])
                                                 {
-                                                    if (index == -1) index = this.activeStates.Insert(el_hash);
-                                                    this.activeStates.Values[index].key = currentList.key;
-                                                    this.activeStates.Values[index].state = ns;
-                                                    this.activeStates.Values[index].register = newReg;
-                                                    this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                    if (index != -1)
+                                                    {
+                                                        this.activeStates.Values[index].key = currentList.key;
+                                                        this.activeStates.Values[index].state = ns;
+                                                        this.activeStates.Values[index].register = newReg;
+                                                        this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                    index = -1;
+                                                        index = -1;
+                                                    }
+                                                    else
+                                                    {
+                                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                        newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                        {
+                                                            key = currentList.key,
+                                                            state = ns,
+                                                            register = newReg,
+                                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                                        });
+                                                    }
 
                                                     ended = false;
 
@@ -274,6 +321,12 @@ namespace Microsoft.StreamProcessing
                         }
                         if (index == orig_index) this.activeFindTraverser.Remove();
                         if (this.IsDeterministic) break; // We are guaranteed to have only one active state
+                    }
+
+                    // Now that we are done traversing the current active states, add any new ones.
+                    foreach (var newActiveState in newActiveStates)
+                    {
+                        this.activeStates.Insert(el_hash, newActiveState);
                     }
                 }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_SingleEvent.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/CompiledPartitionedAfaPipe_SingleEvent.cs
@@ -160,6 +160,8 @@ namespace Microsoft.StreamProcessing
                             {
                                 int orig_index;
 
+                                // Track which active states need to be inserted after the current traversal
+                                var newActiveStates = new List<GroupedActiveState<TKey, TRegister>>();
                                 while (activeFindTraverser.Next(out int index))
                                 {
                                     orig_index = index;
@@ -219,13 +221,28 @@ namespace Microsoft.StreamProcessing
 
                                                         if (this.hasOutgoingArcs[ns])
                                                         {
-                                                            if (index == -1) index = this.activeStates.Insert(src_hash[i]);
-                                                            this.activeStates.Values[index].key = srckey[i];
-                                                            this.activeStates.Values[index].state = ns;
-                                                            this.activeStates.Values[index].register = newReg;
-                                                            this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                            // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                            // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                            if (index != -1)
+                                                            {
+                                                                this.activeStates.Values[index].key = srckey[i];
+                                                                this.activeStates.Values[index].state = ns;
+                                                                this.activeStates.Values[index].register = newReg;
+                                                                this.activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                            index = -1;
+                                                                index = -1;
+                                                            }
+                                                            else
+                                                            {
+                                                                // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                                newActiveStates.Add(new GroupedActiveState<TKey, TRegister>
+                                                                {
+                                                                    key = srckey[i],
+                                                                    state = ns,
+                                                                    register = newReg,
+                                                                    PatternStartTimestamp = state.PatternStartTimestamp,
+                                                                });
+                                                            }
 
                                                             ended = false;
 
@@ -248,6 +265,12 @@ namespace Microsoft.StreamProcessing
 
                                     if (index == orig_index) activeFindTraverser.Remove();
                                     if (this.IsDeterministic) break; // We are guaranteed to have only one active state
+                                }
+
+                                // Now that we are done traversing the current active states, add any new ones.
+                                foreach (var newActiveState in newActiveStates)
+                                {
+                                    this.activeStates.Insert(src_hash[i], newActiveState);
                                 }
                             }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/GroupedAfaEventListTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/GroupedAfaEventListTemplate.tt
@@ -77,7 +77,9 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
             if (activeFindTraverser.Find(el_hash))
             {
                 int index, orig_index;
-
+                
+                // Track which active states need to be inserted after the current traversal
+                var newActiveStates = new List<GroupedActiveState<<#= TKey #>, <#= TRegister #>>>();
                 while (activeFindTraverser.Next(out index))
                 {
                     orig_index = index;
@@ -104,13 +106,29 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
                                     <# if (hasOutgoingArcs[ns]) { #>
 
                                     // target node has outgoing edges
-                                    if (index == -1) index = activeStates.Insert(el_hash);
-                                    activeStates.Values[index].key = currentList.key;
-                                    activeStates.Values[index].state = <#= ns #>;
-                                    activeStates.Values[index].register = newReg;
-                                    activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                    // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                    // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                    if (index != -1)
+                                    {
+                                        activeStates.Values[index].key = currentList.key;
+                                        activeStates.Values[index].state = <#= ns #>;
+                                        activeStates.Values[index].register = newReg;
+                                        activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                    index = -1;
+                                        index = -1;
+                                    }
+                                    else
+                                    {
+                                        // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                        newActiveStates.Add(new GroupedActiveState<<#= TKey #>, <#= TRegister #>>
+                                        {
+                                            key = currentList.key,
+                                            state = <#= ns #>,
+                                            register = newReg,
+                                            PatternStartTimestamp = state.PatternStartTimestamp,
+                                        });
+                                    }
+
                                     ended = false;
                                     <# } else { #>
 
@@ -129,6 +147,12 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
                     }
                     if (index == orig_index) activeFindTraverser.Remove();
                     if (IsDeterministic) break; // We are guaranteed to have only one active state
+                }
+
+                // Now that we are done traversing the current active states, add any new ones.
+                foreach (var newActiveState in newActiveStates)
+                {
+                    this.activeStates.Insert(el_hash, newActiveState);
                 }
             }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/GroupedAfaMultiEventTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/GroupedAfaMultiEventTemplate.tt
@@ -206,6 +206,9 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
 
                             if (found)
                             {
+                                // Track which active states need to be inserted after the current traversal
+                                var newActiveStates = new List<GroupedActiveStateAccumulator<<#= TKey #>, <#= TPayload #>, <#= TRegister #>, <#= TAccumulator #>>>();
+
                                 int activeFind_index;
                                 while (activeFindTraverser.Next(out activeFind_index))
                                 {
@@ -219,21 +222,44 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
                                             <# foreach (var sourceNodeInfo in this.edgeInfos) { #>
 
                                             case <#= sourceNodeInfo.Item1 #> :
+                                            {
                                                 <# foreach (var arcinfo in sourceNodeInfo.Item2) { #>
+                                                
 
-                                                if (activeFind_index == -1) activeFind_index = activeStates.Insert(src_hash[i]);
-                                                activeStates.Values[activeFind_index].arcinfo = null /*arcinfo*/;
-                                                activeStates.Values[activeFind_index].key = state.key;
-                                                activeStates.Values[activeFind_index].fromState = state.toState;
-                                                activeStates.Values[activeFind_index].toState = <#= arcinfo.TargetNode #>;
-                                                activeStates.Values[activeFind_index].PatternStartTimestamp = state.PatternStartTimestamp;
-                                                activeStates.Values[activeFind_index].register = state.register;
-                                                activeStates.Values[activeFind_index].accumulator = <#= arcinfo.Initialize("synctime", "state.register") #>;
-                                                activeStates.Values[activeFind_index].accumulator = <#= arcinfo.Accumulate("synctime", "batch[i]", "state.register", "activeStates.Values[activeFind_index].accumulator") #>;
-                                                activeFind_index = -1;
+                                                // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                if (activeFind_index != -1)
+                                                {
+                                                    activeStates.Values[activeFind_index].arcinfo = null;
+                                                    activeStates.Values[activeFind_index].key = state.key;
+                                                    activeStates.Values[activeFind_index].fromState = state.toState;
+                                                    activeStates.Values[activeFind_index].toState = <#= arcinfo.TargetNode #>;
+                                                    activeStates.Values[activeFind_index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    activeStates.Values[activeFind_index].register = state.register;
+                                                    activeStates.Values[activeFind_index].accumulator = <#= arcinfo.Initialize("synctime", "state.register") #>;
+                                                    activeStates.Values[activeFind_index].accumulator = <#= arcinfo.Accumulate("synctime", "batch[i]", "state.register", "activeStates.Values[activeFind_index].accumulator") #>;
+
+                                                    activeFind_index = -1;
+                                                }
+                                                else
+                                                {
+                                                    // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                    var accumulator = <#= arcinfo.Initialize("synctime", "state.register") #>;
+                                                    newActiveStates.Add(new GroupedActiveStateAccumulator<<#= TKey #>, <#= TPayload #>, <#= TRegister #>, <#= TAccumulator #>>
+                                                    {
+                                                        arcinfo = null,
+                                                        key = state.key,
+                                                        fromState = state.toState,
+                                                        toState = <#= arcinfo.TargetNode #>,
+                                                        PatternStartTimestamp = state.PatternStartTimestamp,
+                                                        register = state.register,
+                                                        accumulator = <#= arcinfo.Accumulate("synctime", "batch[i]", "state.register", "accumulator") #>,
+                                                    });
+                                                }
                                                 <# } #>
 
                                                 break;
+                                            }
                                             <# } #>
 
                                         } // end switch
@@ -241,6 +267,12 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
 
                                     // Remove current state
                                     if (activeFind_index != -1) activeFindTraverser.Remove();
+                                }
+
+                                // Now that we are done traversing the current active states, add any new ones.
+                                foreach (var newActiveState in newActiveStates)
+                                {
+                                    this.activeStates.Insert(src_hash[i], newActiveState);
                                 }
                             }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/GroupedAfaTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/GroupedAfaTemplate.cs
@@ -260,7 +260,13 @@ using Microsoft.StreamProcessing.Internal.Collections;
                         if (activeFindTraverser.Find(src_hash[i]))
                         {
                             int index, orig_index;
-
+                            
+                            // Track which active states need to be inserted after the current traversal
+                            var newActiveStates = new List<GroupedActiveState<");
+            this.Write(this.ToStringHelper.ToStringWithCulture(TKey));
+            this.Write(", ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(TRegister));
+            this.Write(@">>();
                             while (activeFindTraverser.Next(out index))
                             {
                                 orig_index = index;
@@ -295,15 +301,36 @@ using Microsoft.StreamProcessing.Internal.Collections;
  if (hasOutgoingArcs[ns]) { 
             this.Write(@"
                                                 // target node has outgoing edges
-                                                if (index == -1) index = activeStates.Insert(src_hash[i]);
-                                                activeStates.Values[index].key = srckey[i];
-                                                activeStates.Values[index].state = ");
+                                                // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                if (index != -1)
+                                                {
+                                                    activeStates.Values[index].key = srckey[i];
+                                                    activeStates.Values[index].state = ");
             this.Write(this.ToStringHelper.ToStringWithCulture(ns));
             this.Write(@";
-                                                activeStates.Values[index].register = newReg;
-                                                activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                    activeStates.Values[index].register = newReg;
+                                                    activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                index = -1;
+                                                    index = -1;
+                                                }
+                                                else
+                                                {
+                                                    // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                    newActiveStates.Add(new GroupedActiveState<");
+            this.Write(this.ToStringHelper.ToStringWithCulture(TKey));
+            this.Write(", ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(TRegister));
+            this.Write(">\r\n                                                    {\r\n                       " +
+                    "                                 key = srckey[i],\r\n                             " +
+                    "                           state = ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(ns));
+            this.Write(@",
+                                                        register = newReg,
+                                                        PatternStartTimestamp = state.PatternStartTimestamp,
+                                                    });
+                                                }
+
                                                 ended = false;
                                                 ");
  } else { 
@@ -323,6 +350,12 @@ using Microsoft.StreamProcessing.Internal.Collections;
 
                                 }
                                 if (index == orig_index) activeFindTraverser.Remove();
+                            }
+                            
+                            // Now that we are done traversing the current active states, add any new ones.
+                            foreach (var newActiveState in newActiveStates)
+                            {
+                                this.activeStates.Insert(src_hash[i], newActiveState);
                             }
                         }
 

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/GroupedAfaTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/Afa/GroupedAfaTemplate.tt
@@ -191,7 +191,9 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
                         if (activeFindTraverser.Find(src_hash[i]))
                         {
                             int index, orig_index;
-
+                            
+                            // Track which active states need to be inserted after the current traversal
+                            var newActiveStates = new List<GroupedActiveState<<#= TKey #>, <#= TRegister #>>>();
                             while (activeFindTraverser.Next(out index))
                             {
                                 orig_index = index;
@@ -218,13 +220,29 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
                                                 <# if (hasOutgoingArcs[ns]) { #>
 
                                                 // target node has outgoing edges
-                                                if (index == -1) index = activeStates.Insert(src_hash[i]);
-                                                activeStates.Values[index].key = srckey[i];
-                                                activeStates.Values[index].state = <#= ns #>;
-                                                activeStates.Values[index].register = newReg;
-                                                activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
+                                                // Since we will eventually remove this state/index from activeStates, attempt to reuse this index for the outgoing state instead of deleting/re-adding
+                                                // If index is already -1, this means we've already reused the state and must allocate/insert a new index for the outgoing state.
+                                                if (index != -1)
+                                                {
+                                                    activeStates.Values[index].key = srckey[i];
+                                                    activeStates.Values[index].state = <#= ns #>;
+                                                    activeStates.Values[index].register = newReg;
+                                                    activeStates.Values[index].PatternStartTimestamp = state.PatternStartTimestamp;
 
-                                                index = -1;
+                                                    index = -1;
+                                                }
+                                                else
+                                                {
+                                                    // Do not attempt to insert directly into activeStates, as that could corrupt the traversal state.
+                                                    newActiveStates.Add(new GroupedActiveState<<#= TKey #>, <#= TRegister #>>
+                                                    {
+                                                        key = srckey[i],
+                                                        state = <#= ns #>,
+                                                        register = newReg,
+                                                        PatternStartTimestamp = state.PatternStartTimestamp,
+                                                    });
+                                                }
+
                                                 ended = false;
                                                 <# } else { #>
 
@@ -243,6 +261,12 @@ internal sealed class <#= className #> : CompiledAfaPipeBase<<#= TKey #>, <#= TP
 
                                 }
                                 if (index == orig_index) activeFindTraverser.Remove();
+                            }
+                            
+                            // Now that we are done traversing the current active states, add any new ones.
+                            foreach (var newActiveState in newActiveStates)
+                            {
+                                this.activeStates.Insert(src_hash[i], newActiveState);
                             }
                         }
 


### PR DESCRIPTION
Currently, Afa operators use a pattern of traversing a FastMap and inserting into that FastMap during the traversal. While this works most of the time, this can cause problems if the insertion results in the FastMap increasing its capacity and thus rehashing all indexes, thus invalidating the indexes/hashes stored in the traverser. This change modifies all instances of this pattern to store the new elements that need to be inserted into the FastMap and insert them after the traversal completes. Note that these elements will be excluded from the in-progress traversal both before and after this change.