### PR TITLE
NET 5.0 Support

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Transformer/TemplateClasses.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Transformer/TemplateClasses.cs
@@ -27,7 +27,7 @@ namespace Microsoft.StreamProcessing
     internal static class Transformer
     {
         private static readonly bool IsNetCore = RuntimeInformation.FrameworkDescription.Contains(".NET Core") ||
-            RuntimeInformation.FrameworkDescription.Contains(".NET 5");
+            RuntimeInformation.FrameworkDescription.Contains(".NET 5") || RuntimeInformation.FrameworkDescription.Contains(".NET 6");
 
         private static readonly Lazy<IEnumerable<MetadataReference>> baseAssemblyReferences
             = new Lazy<IEnumerable<MetadataReference>>(() => IsNetCore ? GetNetCoreAssemblyReferences() : GetNetFrameworkAssemblyReferences());

--- a/Sources/Core/Microsoft.StreamProcessing/Transformer/TemplateClasses.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Transformer/TemplateClasses.cs
@@ -26,7 +26,8 @@ namespace Microsoft.StreamProcessing
 {
     internal static class Transformer
     {
-        private static readonly bool IsNetCore = RuntimeInformation.FrameworkDescription.Contains(".NET Core");
+        private static readonly bool IsNetCore = RuntimeInformation.FrameworkDescription.Contains(".NET Core") ||
+            RuntimeInformation.FrameworkDescription.Contains(".NET 5");
 
         private static readonly Lazy<IEnumerable<MetadataReference>> baseAssemblyReferences
             = new Lazy<IEnumerable<MetadataReference>>(() => IsNetCore ? GetNetCoreAssemblyReferences() : GetNetFrameworkAssemblyReferences());


### PR DESCRIPTION
Currently NET 5.0 isn't a supported target framework since it doesn't get recognized as a .Net Core framework due to the framework description not having "Core" in its name. This causes Net Framework assembly references to be used instead of Net Core, and leads to an error when compiling generated source code.