### PR TITLE
Update instance of aggregate's key in case consumer tracks its lifetime

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/PartitionedSnapshotWindowHoppingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/PartitionedSnapshotWindowHoppingPipe.cs
@@ -172,36 +172,43 @@ namespace Microsoft.StreamProcessing
 
                         // No output because initial state is empty
                     }
-                    else if (entry.heldAggregates.Add(aggindex))
-                    {
-                        // First time group is active for this time
-                        heldState = this.aggregateByKey.entries[aggindex].value;
-                        if (syncTime > heldState.timestamp)
-                        {
-                            if (heldState.active > 0)
-                            {
-                                // Output end edge
-                                int c = this.batch.Count;
-                                this.batch.vsync.col[c] = syncTime;
-                                this.batch.vother.col[c] = heldState.timestamp;
-                                this.batch.payload.col[c] = this.computeResult(heldState.state);
-                                this.batch.key.col[c] = colkey[i];
-                                this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
-                                this.batch.Count++;
-                                if (this.batch.Count == Config.DataBatchSize)
-                                {
-                                    this.batch.iter = batch.iter;
-                                    FlushContents();
-                                    this.batch.iter = batch.iter;
-                                }
-                            }
-                            heldState.timestamp = syncTime;
-                        }
-                    }
                     else
                     {
-                        // read new currentState from _heldAgg index
-                        heldState = this.aggregateByKey.entries[aggindex].value;
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = colkey[i];
+
+                        if (entry.heldAggregates.Add(aggindex))
+                        {
+                            // First time group is active for this time
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                            if (syncTime > heldState.timestamp)
+                            {
+                                if (heldState.active > 0)
+                                {
+                                    // Output end edge
+                                    int c = this.batch.Count;
+                                    this.batch.vsync.col[c] = syncTime;
+                                    this.batch.vother.col[c] = heldState.timestamp;
+                                    this.batch.payload.col[c] = this.computeResult(heldState.state);
+                                    this.batch.key.col[c] = colkey[i];
+                                    this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
+                                    this.batch.Count++;
+                                    if (this.batch.Count == Config.DataBatchSize)
+                                    {
+                                        this.batch.iter = batch.iter;
+                                        FlushContents();
+                                        this.batch.iter = batch.iter;
+                                    }
+                                }
+                                heldState.timestamp = syncTime;
+                            }
+                        }
+                        else
+                        {
+                            // read new currentState from _heldAgg index
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                        }
                     }
 
                     if (col_vsync[i] < col_vother[i]) // insert event

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingPipe.cs
@@ -152,31 +152,38 @@ namespace Microsoft.StreamProcessing
 
                         // No output because initial state is empty
                     }
-                    else if (this.heldAggregates.Add(aggindex))
-                    {
-                        // First time group is active for this time
-                        heldState = this.aggregateByKey.entries[aggindex].value;
-                        if (syncTime > heldState.timestamp)
-                        {
-                            if (heldState.active > 0)
-                            {
-                                // Output end edge
-                                int c = this.batch.Count;
-                                this.batch.vsync.col[c] = syncTime;
-                                this.batch.vother.col[c] = heldState.timestamp;
-                                this.batch.payload.col[c] = this.computeResult(heldState.state);
-                                this.batch.key.col[c] = colkey[i];
-                                this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
-                                this.batch.Count++;
-                                if (this.batch.Count == Config.DataBatchSize) FlushContents();
-                            }
-                            heldState.timestamp = syncTime;
-                        }
-                    }
                     else
                     {
-                        // read new currentState from _heldAgg index
-                        heldState = this.aggregateByKey.entries[aggindex].value;
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = colkey[i];
+
+                        if (this.heldAggregates.Add(aggindex))
+                        {
+                            // First time group is active for this time
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                            if (syncTime > heldState.timestamp)
+                            {
+                                if (heldState.active > 0)
+                                {
+                                    // Output end edge
+                                    int c = this.batch.Count;
+                                    this.batch.vsync.col[c] = syncTime;
+                                    this.batch.vother.col[c] = heldState.timestamp;
+                                    this.batch.payload.col[c] = this.computeResult(heldState.state);
+                                    this.batch.key.col[c] = colkey[i];
+                                    this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
+                                    this.batch.Count++;
+                                    if (this.batch.Count == Config.DataBatchSize) FlushContents();
+                                }
+                                heldState.timestamp = syncTime;
+                            }
+                        }
+                        else
+                        {
+                            // read new currentState from _heldAgg index
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                        }
                     }
 
                     if (col_vsync[i] < col_vother[i]) // insert event

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingTemplate.cs
@@ -542,6 +542,10 @@ using Microsoft.StreamProcessing.Aggregates;
                     }
                     else
                     {
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = currentKey;
+
                         currentState = this.aggregateByKey.entries[aggindex].value;
                         if (syncTime > currentState.timestamp)
                         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Hopping/SnapshotWindowHoppingTemplate.tt
@@ -374,6 +374,10 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
                     }
                     else
                     {
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = currentKey;
+
                         currentState = this.aggregateByKey.entries[aggindex].value;
                         if (syncTime > currentState.timestamp)
                         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/PartitionedSnapshotWindowPriorityQueuePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/PartitionedSnapshotWindowPriorityQueuePipe.cs
@@ -173,30 +173,37 @@ namespace Microsoft.StreamProcessing
                     }
 
                     // First time group is active for this time
-                    else if (entry.heldAggregates.Add(aggindex))
-                    {
-                        heldState = this.aggregateByKey.entries[aggindex].value;
-                        if (syncTime > heldState.timestamp)
-                        {
-                            if (heldState.active > 0)
-                            {
-                                // Output end edge
-                                int c = this.batch.Count;
-                                this.batch.vsync.col[c] = syncTime;
-                                this.batch.vother.col[c] = heldState.timestamp;
-                                this.batch.payload.col[c] = this.computeResult(heldState.state);
-                                this.batch.key.col[c] = colkey[i];
-                                this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
-                                this.batch.Count++;
-                                if (this.batch.Count == Config.DataBatchSize) FlushContents();
-                            }
-                            heldState.timestamp = syncTime;
-                        }
-                    }
                     else
                     {
-                        // read new currentState from _heldAgg index
-                        heldState = this.aggregateByKey.entries[aggindex].value;
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = colkey[i];
+
+                        if (entry.heldAggregates.Add(aggindex))
+                        {
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                            if (syncTime > heldState.timestamp)
+                            {
+                                if (heldState.active > 0)
+                                {
+                                    // Output end edge
+                                    int c = this.batch.Count;
+                                    this.batch.vsync.col[c] = syncTime;
+                                    this.batch.vother.col[c] = heldState.timestamp;
+                                    this.batch.payload.col[c] = this.computeResult(heldState.state);
+                                    this.batch.key.col[c] = colkey[i];
+                                    this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
+                                    this.batch.Count++;
+                                    if (this.batch.Count == Config.DataBatchSize) FlushContents();
+                                }
+                                heldState.timestamp = syncTime;
+                            }
+                        }
+                        else
+                        {
+                            // read new currentState from _heldAgg index
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                        }
                     }
 
                     if (col_vsync[i] < col_vother[i]) // insert event

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueuePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueuePipe.cs
@@ -150,36 +150,43 @@ namespace Microsoft.StreamProcessing
 
                         // No output because initial state is empty
                     }
-                    else if (this.heldAggregates.Add(aggindex))
-                    {
-                        // First time group is active for this time
-                        heldState = this.aggregateByKey.entries[aggindex].value;
-                        if (syncTime > heldState.timestamp)
-                        {
-                            if (heldState.active > 0)
-                            {
-                                // Output end edge
-                                int c = this.batch.Count;
-                                this.batch.vsync.col[c] = syncTime;
-                                this.batch.vother.col[c] = heldState.timestamp;
-                                this.batch.payload.col[c] = this.computeResult(heldState.state);
-                                this.batch.key.col[c] = colkey[i];
-                                this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
-                                this.batch.Count++;
-                                if (this.batch.Count == Config.DataBatchSize)
-                                {
-                                    this.batch.iter = batch.iter;
-                                    FlushContents();
-                                    this.batch.iter = batch.iter;
-                                }
-                            }
-                            heldState.timestamp = syncTime;
-                        }
-                    }
                     else
                     {
-                        // read new currentState from _heldAgg index
-                        heldState = this.aggregateByKey.entries[aggindex].value;
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = colkey[i];
+
+                        if (this.heldAggregates.Add(aggindex))
+                        {
+                            // First time group is active for this time
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                            if (syncTime > heldState.timestamp)
+                            {
+                                if (heldState.active > 0)
+                                {
+                                    // Output end edge
+                                    int c = this.batch.Count;
+                                    this.batch.vsync.col[c] = syncTime;
+                                    this.batch.vother.col[c] = heldState.timestamp;
+                                    this.batch.payload.col[c] = this.computeResult(heldState.state);
+                                    this.batch.key.col[c] = colkey[i];
+                                    this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
+                                    this.batch.Count++;
+                                    if (this.batch.Count == Config.DataBatchSize)
+                                    {
+                                        this.batch.iter = batch.iter;
+                                        FlushContents();
+                                        this.batch.iter = batch.iter;
+                                    }
+                                }
+                                heldState.timestamp = syncTime;
+                            }
+                        }
+                        else
+                        {
+                            // read new currentState from _heldAgg index
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                        }
                     }
 
                     if (col_vsync[i] < col_vother[i]) // insert event

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueueTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueueTemplate.cs
@@ -537,6 +537,10 @@ using Microsoft.StreamProcessing.Aggregates;
                     }
                     else
                     {
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = currentKey;
+
                         currentState = this.aggregateByKey.entries[aggindex].value;
                         if (syncTime > currentState.timestamp)
                         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueueTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/PriorityQueue/SnapshotWindowPriorityQueueTemplate.tt
@@ -369,6 +369,10 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
                     }
                     else
                     {
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = currentKey;
+
                         currentState = this.aggregateByKey.entries[aggindex].value;
                         if (syncTime > currentState.timestamp)
                         {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/PartitionedSnapshotWindowSlidingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/PartitionedSnapshotWindowSlidingPipe.cs
@@ -170,36 +170,43 @@ namespace Microsoft.StreamProcessing
 
                         // No output because initial state is empty
                     }
-                    else if (entry.heldAggregates.Add(aggindex))
-                    {
-                        // First time group is active for this time
-                        heldState = this.aggregateByKey.entries[aggindex].value;
-                        if (syncTime > heldState.timestamp)
-                        {
-                            if (heldState.active > 0)
-                            {
-                                // Output end edge
-                                int c = this.batch.Count;
-                                this.batch.vsync.col[c] = syncTime;
-                                this.batch.vother.col[c] = heldState.timestamp;
-                                this.batch.payload.col[c] = this.computeResult(heldState.state);
-                                this.batch.key.col[c] = colkey[i];
-                                this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
-                                this.batch.Count++;
-                                if (this.batch.Count == Config.DataBatchSize)
-                                {
-                                    this.batch.iter = batch.iter;
-                                    FlushContents();
-                                    this.batch.iter = batch.iter;
-                                }
-                            }
-                            heldState.timestamp = syncTime;
-                        }
-                    }
                     else
                     {
-                        // read new currentState from _heldAgg index
-                        heldState = this.aggregateByKey.entries[aggindex].value;
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = colkey[i];
+
+                        if (entry.heldAggregates.Add(aggindex))
+                        {
+                            // First time group is active for this time
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                            if (syncTime > heldState.timestamp)
+                            {
+                                if (heldState.active > 0)
+                                {
+                                    // Output end edge
+                                    int c = this.batch.Count;
+                                    this.batch.vsync.col[c] = syncTime;
+                                    this.batch.vother.col[c] = heldState.timestamp;
+                                    this.batch.payload.col[c] = this.computeResult(heldState.state);
+                                    this.batch.key.col[c] = colkey[i];
+                                    this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
+                                    this.batch.Count++;
+                                    if (this.batch.Count == Config.DataBatchSize)
+                                    {
+                                        this.batch.iter = batch.iter;
+                                        FlushContents();
+                                        this.batch.iter = batch.iter;
+                                    }
+                                }
+                                heldState.timestamp = syncTime;
+                            }
+                        }
+                        else
+                        {
+                            // read new currentState from _heldAgg index
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                        }
                     }
 
                     if (col_vsync[i] < col_vother[i]) // insert event

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingPipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingPipe.cs
@@ -151,31 +151,38 @@ namespace Microsoft.StreamProcessing
 
                         // No output because initial state is empty
                     }
-                    else if (this.heldAggregates.Add(aggindex))
-                    {
-                        // First time group is active for this time
-                        heldState = this.aggregateByKey.entries[aggindex].value;
-                        if (syncTime > heldState.timestamp)
-                        {
-                            if (heldState.active > 0)
-                            {
-                                // Output end edge
-                                int c = this.batch.Count;
-                                this.batch.vsync.col[c] = syncTime;
-                                this.batch.vother.col[c] = heldState.timestamp;
-                                this.batch.payload.col[c] = this.computeResult(heldState.state);
-                                this.batch.key.col[c] = colkey[i];
-                                this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
-                                this.batch.Count++;
-                                if (this.batch.Count == Config.DataBatchSize) FlushContents();
-                            }
-                            heldState.timestamp = syncTime;
-                        }
-                    }
                     else
                     {
-                        // read new currentState from _heldAgg index
-                        heldState = this.aggregateByKey.entries[aggindex].value;
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = colkey[i];
+
+                        if (this.heldAggregates.Add(aggindex))
+                        {
+                            // First time group is active for this time
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                            if (syncTime > heldState.timestamp)
+                            {
+                                if (heldState.active > 0)
+                                {
+                                    // Output end edge
+                                    int c = this.batch.Count;
+                                    this.batch.vsync.col[c] = syncTime;
+                                    this.batch.vother.col[c] = heldState.timestamp;
+                                    this.batch.payload.col[c] = this.computeResult(heldState.state);
+                                    this.batch.key.col[c] = colkey[i];
+                                    this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
+                                    this.batch.Count++;
+                                    if (this.batch.Count == Config.DataBatchSize) FlushContents();
+                                }
+                                heldState.timestamp = syncTime;
+                            }
+                        }
+                        else
+                        {
+                            // read new currentState from _heldAgg index
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                        }
                     }
 
                     if (col_vsync[i] < col_vother[i]) // insert event

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingTemplate.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingTemplate.cs
@@ -547,6 +547,10 @@ using Microsoft.StreamProcessing.Aggregates;
                         }
                         else
                         {
+                            // Update instance of key in case consumer tracks lifetime of the key object.
+                            // Otherwise it may live past the Window lifetime.
+                            this.aggregateByKey.entries[aggindex].key = currentKey;
+
                             currentState = this.aggregateByKey.entries[aggindex].value;
                             if (syncTime > currentState.timestamp)
                             {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingTemplate.tt
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/Sliding/SnapshotWindowSlidingTemplate.tt
@@ -373,6 +373,10 @@ internal sealed class <#= className #><#= genericParameters #> : UnaryPipe<<#= T
                         }
                         else
                         {
+                            // Update instance of key in case consumer tracks lifetime of the key object.
+                            // Otherwise it may live past the Window lifetime.
+                            this.aggregateByKey.entries[aggindex].key = currentKey;
+
                             currentState = this.aggregateByKey.entries[aggindex].value;
                             if (syncTime > currentState.timestamp)
                             {

--- a/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/StartEdge/SnapshotWindowStartEdgePipe.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Operators/SnapshotWindow/StartEdge/SnapshotWindowStartEdgePipe.cs
@@ -151,28 +151,35 @@ namespace Microsoft.StreamProcessing
 
                         // No output because initial state is empty
                     }
-                    else if (this.heldAggregates.Add(aggindex))
-                    {
-                        // First time group is active for this time
-                        heldState = this.aggregateByKey.entries[aggindex].value;
-                        if (syncTime > heldState.timestamp)
-                        {
-                            // Output end edge
-                            int c = this.batch.Count;
-                            this.batch.vsync.col[c] = syncTime;
-                            this.batch.vother.col[c] = heldState.timestamp;
-                            this.batch.payload.col[c] = this.computeResult(heldState.state);
-                            this.batch.key.col[c] = colkey[i];
-                            this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
-                            this.batch.Count++;
-                            if (this.batch.Count == Config.DataBatchSize) FlushContents();
-                            heldState.timestamp = syncTime;
-                        }
-                    }
                     else
                     {
-                        // read new currentState from _heldAgg index
-                        heldState = this.aggregateByKey.entries[aggindex].value;
+                        // Update instance of key in case consumer tracks lifetime of the key object.
+                        // Otherwise it may live past the Window lifetime.
+                        this.aggregateByKey.entries[aggindex].key = colkey[i];
+
+                        if (this.heldAggregates.Add(aggindex))
+                        {
+                            // First time group is active for this time
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                            if (syncTime > heldState.timestamp)
+                            {
+                                // Output end edge
+                                int c = this.batch.Count;
+                                this.batch.vsync.col[c] = syncTime;
+                                this.batch.vother.col[c] = heldState.timestamp;
+                                this.batch.payload.col[c] = this.computeResult(heldState.state);
+                                this.batch.key.col[c] = colkey[i];
+                                this.batch.hash.col[c] = this.keyComparerGetHashCode(colkey[i]);
+                                this.batch.Count++;
+                                if (this.batch.Count == Config.DataBatchSize) FlushContents();
+                                heldState.timestamp = syncTime;
+                            }
+                        }
+                        else
+                        {
+                            // read new currentState from _heldAgg index
+                            heldState = this.aggregateByKey.entries[aggindex].value;
+                        }
                     }
 
                     // It's always a start edge

--- a/Sources/Test/SimpleTesting/Streamables/GroupKeyLifetimeTest.cs
+++ b/Sources/Test/SimpleTesting/Streamables/GroupKeyLifetimeTest.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Subjects;
+using Microsoft.StreamProcessing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SimpleTesting
+{
+    [TestClass]
+    public class GroupKeyLifetimeTest : TestWithConfigSettingsAndMemoryLeakDetection
+    {
+        [TestMethod, TestCategory("Gated")]
+        public void GroupKeyLifetimeAccessTest()
+        {
+            var inputEvents = new StreamEvent<int>[]
+            {
+                StreamEvent.CreateStart(100, 1),
+                StreamEvent.CreateStart(200, 2),
+                StreamEvent.CreateStart(300, 3),
+                StreamEvent.CreateStart(400, 4),
+                StreamEvent.CreatePunctuation<int>(400),
+
+                StreamEvent.CreateStart(500, 5),
+                StreamEvent.CreateStart(600, 6),
+                StreamEvent.CreateStart(700, 7),
+                StreamEvent.CreateStart(800, 8),
+                StreamEvent.CreatePunctuation<int>(800),
+
+                StreamEvent.CreateStart(900, 9),
+                StreamEvent.CreateStart(1000, 10),
+                StreamEvent.CreateStart(1100, 11),
+                StreamEvent.CreateStart(1200, 12),
+                StreamEvent.CreatePunctuation<int>(StreamEvent.InfinitySyncTime)
+            };
+
+            var keyFactory = new TestKeyFactory();
+
+            var subject = new Subject<StreamEvent<int>>();
+            var output = subject
+                            .ToStreamable()
+                            .HoppingWindowLifetime(300, 100)
+                            .GroupApply(
+                                v => keyFactory.Create(v),
+                                w => w.Count(),
+                                (key, count) => new { key.Key, count });
+
+            var outputCounts = new List<ValueTuple<int, ulong>>();
+
+            var subscription = output.ToStreamEventObservable().Subscribe(onNext: item =>
+            {
+                if (item.IsData)
+                {
+                    outputCounts.Add((item.Payload.Key.Key, item.Payload.count));
+                }
+            });
+
+            foreach (var inputEvent in inputEvents.Take(5))
+            {
+                subject.OnNext(inputEvent);
+            }
+
+            var oldKeys = keyFactory.KeysCreated.ToArray();
+
+            foreach (var inputEvent in inputEvents.Skip(5).Take(5))
+            {
+                subject.OnNext(inputEvent);
+            }
+
+            TestKeyFactory.MarkDirty(oldKeys);
+
+            foreach (var inputEvent in inputEvents.Skip(10))
+            {
+                subject.OnNext(inputEvent);
+            }
+
+            // Asserts are done while accessing records in TestKey methods
+            subject.OnCompleted();
+
+            subject.Dispose();
+            subscription.Dispose();
+        }
+
+        private class TestKey : IEquatable<TestKey>
+        {
+            public readonly int Key;
+            public bool isDeleted;
+
+            public TestKey(int key)
+            {
+                this.Key = key;
+                this.isDeleted = false;
+            }
+
+            public bool Equals(TestKey other)
+            {
+                Assert.IsFalse(isDeleted);
+                return (other != null && this.Key == other.Key);
+            }
+
+            public override bool Equals(object obj)
+            {
+                Assert.IsFalse(isDeleted);
+                return Equals(obj as TestKey);
+            }
+
+            public override int GetHashCode()
+            {
+                Assert.IsFalse(isDeleted);
+                return Key;
+            }
+
+            public override string ToString()
+                => $"(Key: {Key}, isDeleted: {isDeleted})";
+        }
+
+        private class TestKeyFactory
+        {
+            public readonly List<TestKey> KeysCreated = new List<TestKey>();
+
+            public static void MarkDirty(IEnumerable<TestKey> keys)
+            {
+                foreach (var key in keys)
+                {
+                    key.isDeleted = true;
+                }
+            }
+
+            public TestKey Create(int value)
+            {
+                var keyValue = value % 2;
+                var key = new TestKey(keyValue);
+                KeysCreated.Add(key);
+                return key;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Trill keeps a reference to grouped key across event data spanning multiple window lifetimes. As long as the key remains similar (as per Equals/GetHashCode return value), the original key object is continued to be used - this causes problem in case the user depends on the life time of object (which is now much older) w.r.t rest of the data.
This PR solves this by updating the grouping key even when it finds a similar old group key in its held state.
