### PR TITLE
Targeting updated to Net7, Net6, Net472; resolved Linux bug; upgraded packages w/ security vulnerabilities

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -51,3 +51,13 @@ csharp_new_line_before_finally = true
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_preserve_single_line_statements = false
+[*.cs]
+
+# Default severity for analyzer diagnostics with category 'StyleCop.CSharp.NamingRules'
+dotnet_analyzer_diagnostic.category-StyleCop.CSharp.NamingRules.severity = none
+
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = none
+
+# SA1314: Type parameter names should begin with T
+dotnet_diagnostic.SA1314.severity = none

--- a/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net472;netcoreapp3.1</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
   </PropertyGroup>
 

--- a/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
   </PropertyGroup>
 
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="3.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.4.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
   </PropertyGroup>
 

--- a/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net472;netcoreapp3.1</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
   </PropertyGroup>
 

--- a/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
   </PropertyGroup>
 
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="3.1.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.4.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />

--- a/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
   </PropertyGroup>
 

--- a/Sources/Core/Microsoft.StreamProcessing/Utilities/Native32.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Utilities/Native32.cs
@@ -74,8 +74,16 @@ namespace Microsoft.StreamProcessing
             {
                 if (utid == pt.Id)
                 {
-                    long AffinityMask = 1 << processor;
-                    pt.ProcessorAffinity = (IntPtr)(AffinityMask); // Set affinity for this
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    {
+                        pt.IdealProcessor = processor;
+                    }
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        long AffinityMask = 1 << processor;
+                        pt.ProcessorAffinity = (IntPtr)(AffinityMask); // Set affinity for this
+                    }
                 }
             }
         }

--- a/Sources/Test/SimpleTesting/GlobalSuppressions.cs
+++ b/Sources/Test/SimpleTesting/GlobalSuppressions.cs
@@ -1,0 +1,24 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsColumnar.CheckpointRegressionColumnar")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsColumnar.MaxBug0Columnar")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsColumnar.MaxBug1Columnar")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsColumnar.MaxBug2Columnar")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsColumnarSmallBatch.CheckpointRegressionColumnarSmallBatch")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsColumnarSmallBatch.MaxBug0ColumnarSmallBatch")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsColumnarSmallBatch.MaxBug1ColumnarSmallBatch")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsColumnarSmallBatch.MaxBug2ColumnarSmallBatch")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsRow.CheckpointRegressionRow")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsRow.MaxBug0Row")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsRow.MaxBug1Row")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsRow.MaxBug2Row")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsRowSmallBatch.CheckpointRegressionRowSmallBatch")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsRowSmallBatch.MaxBug0RowSmallBatch")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsRowSmallBatch.MaxBug1RowSmallBatch")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.CheckpointRestoreTestsRowSmallBatch.MaxBug2RowSmallBatch")]
+[assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:Field names should not use Hungarian notation", Justification = "<Pending>", Scope = "member", Target = "~M:SimpleTesting.Extensions.ToEvents``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Int64},System.Func{``0,System.Int64})~System.Collections.Generic.IEnumerable{Microsoft.StreamProcessing.StreamEvent{``0}}")]

--- a/Sources/Test/SimpleTesting/Macros/LeftOuterJoinTests.cs
+++ b/Sources/Test/SimpleTesting/Macros/LeftOuterJoinTests.cs
@@ -82,8 +82,8 @@ namespace SimpleTesting
             var query =
             leftStream.LeftOuterJoin(rightStream, e => e.field1, e => e.field3,
                (l, r) => l.field2 != "E",
-                (l) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = tmp1, field4 = tmp2 },
-                (l, r) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = r.field3, field4 = r.field4 });
+               (l) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = tmp1, field4 = tmp2 },
+               (l, r) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = r.field3, field4 = r.field4 });
 
             var result = container.RegisterOutput(query, ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData);
             var resultAsync = result.ForEachAsync(o => output.Add(o));
@@ -144,8 +144,8 @@ namespace SimpleTesting
             var query =
             leftStream.LeftOuterJoin(rightStream, e => e.field1, e => e.field3,
                (l, r) => l.field2 != "E",
-                (l) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = tmp1, field4 = tmp2 },
-                (l, r) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = r.field3, field4 = r.field4 });
+               (l) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = tmp1, field4 = tmp2 },
+               (l, r) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = r.field3, field4 = r.field4 });
 
             var result = container.RegisterOutput(query, ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData);
             var resultAsync = result.ForEachAsync(o => output.Add(o));
@@ -205,8 +205,8 @@ namespace SimpleTesting
             var query =
             leftStream.LeftOuterJoin(rightStream, e => e.field1, e => e.field3,
                (l, r) => l.field2 != "E",
-                (l) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = tmp1, field4 = tmp2 },
-                (l, r) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = r.field3, field4 = r.field4 });
+               (l) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = tmp1, field4 = tmp2 },
+               (l, r) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = r.field3, field4 = r.field4 });
 
             var result = container.RegisterOutput(query, ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData);
             var resultAsync = result.ForEachAsync(o => output.Add(o));
@@ -267,8 +267,8 @@ namespace SimpleTesting
             var query =
             leftStream.LeftOuterJoin(rightStream, e => e.field1, e => e.field3,
                (l, r) => l.field2 != "E",
-                (l) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = tmp1, field4 = tmp2 },
-                (l, r) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = r.field3, field4 = r.field4 });
+               (l) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = tmp1, field4 = tmp2 },
+               (l, r) => new MyData3 { field1 = l.field1, field2 = l.field2, field3 = r.field3, field4 = r.field4 });
 
             var result = container.RegisterOutput(query, ReshapingPolicy.CoalesceEndEdges).Where(e => e.IsData);
             var resultAsync = result.ForEachAsync(o => output.Add(o));

--- a/Sources/Test/SimpleTesting/SimpleTesting.csproj
+++ b/Sources/Test/SimpleTesting/SimpleTesting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>net472;net7;net7]};net7211
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
@@ -11,14 +11,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <!--
     Microsoft.NET.Test.Sdk in .NET Core injects a stub main entry point for test execution by default to convert lib projects to console apps.
     Since we have our own entry point to enable manually compiling OutputType of Exe, we need to tell it not to generate one automatically.
   -->
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net472' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != '7.0' ">
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   
@@ -159,6 +159,13 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ShuffleStreamableTests.tt</DependentUpon>
     </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(MSBuildAssemblyVersion)\TextTemplating\Microsoft.TextTemplating.targets" />

--- a/Sources/Test/SimpleTesting/SimpleTesting.csproj
+++ b/Sources/Test/SimpleTesting/SimpleTesting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>net472;net7;net7]};net7211
+    <TargetFrameworks>net6.0;net7.0;net472;netcoreapp3.1</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 

--- a/Sources/Test/SimpleTesting/SimpleTesting.csproj
+++ b/Sources/Test/SimpleTesting/SimpleTesting.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net472</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="System.Reactive.Linq" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
@@ -18,7 +18,7 @@
     Microsoft.NET.Test.Sdk in .NET Core injects a stub main entry point for test execution by default to convert lib projects to console apps.
     Since we have our own entry point to enable manually compiling OutputType of Exe, we need to tell it not to generate one automatically.
   -->
-  <PropertyGroup Condition=" '$(TargetFramework)' != '7.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net472' ">
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   
@@ -162,7 +162,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Update="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Sources/Test/SimpleTesting/Streamables/AfaTests.cs
+++ b/Sources/Test/SimpleTesting/Streamables/AfaTests.cs
@@ -845,15 +845,15 @@ namespace SimpleTesting
             var source = new StreamEvent<Tuple<string, int>>[]
             {
                 StreamEvent.CreateStart(0, new Tuple<string, int>("A", 1)),
-                    StreamEvent.CreateStart(1, new Tuple<string, int>("A", 2)),
-                    StreamEvent.CreateStart(2, new Tuple<string, int>("B", 2)),
+                StreamEvent.CreateStart(1, new Tuple<string, int>("A", 2)),
+                StreamEvent.CreateStart(2, new Tuple<string, int>("B", 2)),
                 StreamEvent.CreateStart(3, new Tuple<string, int>("A", 1)),
                 StreamEvent.CreateStart(4, new Tuple<string, int>("B", 1)),
-                    StreamEvent.CreateStart(5, new Tuple<string, int>("B", 2)),
+                StreamEvent.CreateStart(5, new Tuple<string, int>("B", 2)),
                 StreamEvent.CreateStart(6, new Tuple<string, int>("B", 1)),
                 StreamEvent.CreateStart(7, new Tuple<string, int>("C", 1)),
-                    StreamEvent.CreateStart(8, new Tuple<string, int>("B", 2)),
-                    StreamEvent.CreateStart(9, new Tuple<string, int>("A", 2)),
+                StreamEvent.CreateStart(8, new Tuple<string, int>("B", 2)),
+                StreamEvent.CreateStart(9, new Tuple<string, int>("A", 2)),
             }.ToObservable()
                 .ToStreamable()
                 .AlterEventDuration(7);
@@ -893,18 +893,18 @@ namespace SimpleTesting
             var source = new StreamEvent<Tuple<string, int>>[]
             {
                 StreamEvent.CreateStart(0, new Tuple<string, int>("A", 1)),
-                    StreamEvent.CreateStart(1, new Tuple<string, int>("A", 2)),
-                    StreamEvent.CreateStart(1, new Tuple<string, int>("B", 2)),
+                StreamEvent.CreateStart(1, new Tuple<string, int>("A", 2)),
+                StreamEvent.CreateStart(1, new Tuple<string, int>("B", 2)),
                 StreamEvent.CreateStart(3, new Tuple<string, int>("A", 1)),
 
                 StreamEvent.CreatePunctuation<Tuple<string, int>>(4),
 
                 StreamEvent.CreateStart(4, new Tuple<string, int>("B", 1)),
-                    StreamEvent.CreateStart(4, new Tuple<string, int>("B", 2)),
+                StreamEvent.CreateStart(4, new Tuple<string, int>("B", 2)),
                 StreamEvent.CreateStart(5, new Tuple<string, int>("B", 1)),
                 StreamEvent.CreateStart(5, new Tuple<string, int>("C", 1)),
-                    StreamEvent.CreateStart(6, new Tuple<string, int>("B", 2)),
-                    StreamEvent.CreateStart(7, new Tuple<string, int>("A", 2)),
+                StreamEvent.CreateStart(6, new Tuple<string, int>("B", 2)),
+                StreamEvent.CreateStart(7, new Tuple<string, int>("A", 2)),
 
                 StreamEvent.CreatePunctuation<Tuple<string, int>>(7),
             }.ToObservable()
@@ -959,23 +959,23 @@ namespace SimpleTesting
             var source = new PartitionedStreamEvent<int, string>[]
             {
                 PartitionedStreamEvent.CreateStart(1, 0, "A"),
-                            PartitionedStreamEvent.CreateStart(2, 0, "A"),
+                PartitionedStreamEvent.CreateStart(2, 0, "A"),
                 PartitionedStreamEvent.CreateStart(1, 1, "B"),
                 PartitionedStreamEvent.CreateStart(1, 2, "B"),
-                            PartitionedStreamEvent.CreateStart(2, 2, "B"),
+                PartitionedStreamEvent.CreateStart(2, 2, "B"),
                 PartitionedStreamEvent.CreateStart(1, 3, "A"),
                 PartitionedStreamEvent.CreateStart(1, 4, "C"),
-                            PartitionedStreamEvent.CreateStart(2, 3, "C"),
-                            PartitionedStreamEvent.CreateStart(2, 4, "A"),
+                PartitionedStreamEvent.CreateStart(2, 3, "C"),
+                PartitionedStreamEvent.CreateStart(2, 4, "A"),
                 PartitionedStreamEvent.CreateStart(1, 5, "A"),
                 PartitionedStreamEvent.CreateStart(1, 6, "B"),
-                            PartitionedStreamEvent.CreateStart(2, 5, "B"),
+                PartitionedStreamEvent.CreateStart(2, 5, "B"),
                 PartitionedStreamEvent.CreateStart(1, 7, "B"),
-                            PartitionedStreamEvent.CreateStart(2, 6, "B"),
+                PartitionedStreamEvent.CreateStart(2, 6, "B"),
                 PartitionedStreamEvent.CreateStart(1, 8, "B"),
                 PartitionedStreamEvent.CreateStart(1, 9, "A"),
-                            PartitionedStreamEvent.CreateStart(2, 7, "A"),
-                            PartitionedStreamEvent.CreateStart(2, 8, "B")
+                PartitionedStreamEvent.CreateStart(2, 7, "A"),
+                PartitionedStreamEvent.CreateStart(2, 8, "B")
             }.ToObservable()
                 .ToStreamable()
                 .AlterEventDuration(7);
@@ -1016,23 +1016,23 @@ namespace SimpleTesting
             var source = new PartitionedStreamEvent<int, string>[]
             {
                 PartitionedStreamEvent.CreateStart(1, 0, "A"),
-                            PartitionedStreamEvent.CreateStart(2, 0, "A"),
+                PartitionedStreamEvent.CreateStart(2, 0, "A"),
                 PartitionedStreamEvent.CreateStart(1, 1, "B"),
                 PartitionedStreamEvent.CreateStart(1, 1, "B"),
-                            PartitionedStreamEvent.CreateStart(2, 0, "B"),
+                PartitionedStreamEvent.CreateStart(2, 0, "B"),
                 PartitionedStreamEvent.CreateStart(1, 3, "A"),
                 PartitionedStreamEvent.CreateStart(1, 4, "C"),
-                            PartitionedStreamEvent.CreateStart(2, 3, "C"),
-                            PartitionedStreamEvent.CreateStart(2, 4, "A"),
+                PartitionedStreamEvent.CreateStart(2, 3, "C"),
+                PartitionedStreamEvent.CreateStart(2, 4, "A"),
                 PartitionedStreamEvent.CreateStart(1, 5, "A"),
                 PartitionedStreamEvent.CreateStart(1, 6, "B"),
-                            PartitionedStreamEvent.CreateStart(2, 4, "B"),
+                PartitionedStreamEvent.CreateStart(2, 4, "B"),
                 PartitionedStreamEvent.CreateStart(1, 7, "B"),
-                            PartitionedStreamEvent.CreateStart(2, 6, "B"),
+                PartitionedStreamEvent.CreateStart(2, 6, "B"),
                 PartitionedStreamEvent.CreateStart(1, 8, "B"),
                 PartitionedStreamEvent.CreateStart(1, 9, "A"),
-                            PartitionedStreamEvent.CreateStart(2, 7, "A"),
-                            PartitionedStreamEvent.CreateStart(2, 8, "B")
+                PartitionedStreamEvent.CreateStart(2, 7, "A"),
+                PartitionedStreamEvent.CreateStart(2, 8, "B")
             }.ToObservable()
                 .ToStreamable()
                 .AlterEventDuration(7);

--- a/Sources/Test/SimpleTesting/Streamables/JoinTests.cs
+++ b/Sources/Test/SimpleTesting/Streamables/JoinTests.cs
@@ -83,7 +83,7 @@ namespace SimpleTesting
                     input2,
                     e => e.field1,
                     e => e,
-                (l, r) => new GameData() { EventType = l.field1, GameId = r, });
+                    (l, r) => new GameData() { EventType = l.field1, GameId = r, });
             var result = query
                 .ToPayloadEnumerable()
                 .ToArray();
@@ -446,7 +446,7 @@ namespace SimpleTesting
                     input2,
                     e => e.field1,
                     e => e,
-                (l, r) => new GameData() { EventType = l.field1, GameId = r, });
+                    (l, r) => new GameData() { EventType = l.field1, GameId = r, });
             var result = query
                 .ToPayloadEnumerable()
                 .ToArray();
@@ -810,7 +810,7 @@ namespace SimpleTesting
                     input2,
                     e => e.field1,
                     e => e,
-                (l, r) => new GameData() { EventType = l.field1, GameId = r, });
+                    (l, r) => new GameData() { EventType = l.field1, GameId = r, });
             var result = query
                 .ToPayloadEnumerable()
                 .ToArray();
@@ -1174,7 +1174,7 @@ namespace SimpleTesting
                     input2,
                     e => e.field1,
                     e => e,
-                (l, r) => new GameData() { EventType = l.field1, GameId = r, });
+                    (l, r) => new GameData() { EventType = l.field1, GameId = r, });
             var result = query
                 .ToPayloadEnumerable()
                 .ToArray();
@@ -1537,7 +1537,7 @@ namespace SimpleTesting
                     input2,
                     e => e.field1,
                     e => e,
-                (l, r) => new GameData() { EventType = l.field1, GameId = r, });
+                    (l, r) => new GameData() { EventType = l.field1, GameId = r, });
             var result = query
                 .ToPayloadEnumerable()
                 .ToArray();
@@ -1900,7 +1900,7 @@ namespace SimpleTesting
                     input2,
                     e => e.field1,
                     e => e,
-                (l, r) => new GameData() { EventType = l.field1, GameId = r, });
+                    (l, r) => new GameData() { EventType = l.field1, GameId = r, });
             var result = query
                 .ToPayloadEnumerable()
                 .ToArray();
@@ -2264,7 +2264,7 @@ namespace SimpleTesting
                     input2,
                     e => e.field1,
                     e => e,
-                (l, r) => new GameData() { EventType = l.field1, GameId = r, });
+                    (l, r) => new GameData() { EventType = l.field1, GameId = r, });
             var result = query
                 .ToPayloadEnumerable()
                 .ToArray();
@@ -2628,7 +2628,7 @@ namespace SimpleTesting
                     input2,
                     e => e.field1,
                     e => e,
-                (l, r) => new GameData() { EventType = l.field1, GameId = r, });
+                    (l, r) => new GameData() { EventType = l.field1, GameId = r, });
             var result = query
                 .ToPayloadEnumerable()
                 .ToArray();

--- a/Sources/Test/TrillPerf/PerformanceTesting.csproj
+++ b/Sources/Test/TrillPerf/PerformanceTesting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net6.0;net7.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net472</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
@@ -10,13 +10,6 @@
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="System.Reactive.Linq" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/Sources/Test/TrillPerf/PerformanceTesting.csproj
+++ b/Sources/Test/TrillPerf/PerformanceTesting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;netcoreapp3.1</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 

--- a/Sources/Test/TrillPerf/PerformanceTesting.csproj
+++ b/Sources/Test/TrillPerf/PerformanceTesting.csproj
@@ -2,14 +2,21 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="System.Reactive.Linq" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
1. Solution updated to target the following framework version currently supported by MS - Net7, Net6, Net472

2. Workaround to issue caused by Windows targeted thread affinity in Native32.cs that causes degraded performance on Amazon (and potentially other) Linux images.  The original Windows method remains unchanged.

3. Upgraded MSTest packages with security vulnerabilities